### PR TITLE
fix: corregir URL artículos en ArticleCard

### DIFF
--- a/docs/FlujoTrabajo.md
+++ b/docs/FlujoTrabajo.md
@@ -8,9 +8,9 @@
 ## 📍 Estado actual
 
 - **Fecha:** 2026-04-25
-- **Fase:** 1 — Esqueleto (sistema editorial en marcha)
-- **Sprint activo:** **Sprint 2 — Content collections + primer artículo** (PR #10, pendiente de CI verde)
-- **Bloqueantes:** CI pasando (pnpm fix aplicado), falta merge de PR #10 a main
+- **Fase:** 1 — Esqueleto (sistema editorial funcionando)
+- **Sprint activo:** **Sprint 3 — SEO técnico + AdSense submit** (por arrancar)
+- **Bloqueantes:** ninguno — dominio y Cloudflare Pages pendientes (tareas 1.10–1.12)
 
 ---
 
@@ -27,17 +27,17 @@
 | 2026-04-25 | Posicionamiento de marca v1 definido (`MarcaPosicionamiento.md`) |
 | 2026-04-25 | Backlog 6 meses + 20 artículos núcleo (`PlanTrabajo.md`) |
 | 2026-04-25 | **Sprint 1 cerrado:** bootstrap Astro 5 + Tailwind 4, CI + Lighthouse, repo GitHub público, branch protection, labels, milestones |
-| 2026-04-25 | **Sprint 2 en PR #10:** sistema editorial completo (ver detalle abajo) |
+| 2026-04-25 | **Sprint 2 cerrado (PR #10 → main):** sistema editorial completo — content collections, layouts, componentes, primer artículo, Lighthouse CI verde |
 
 ---
 
 ## 🎯 Próximos pasos inmediatos (top 5)
 
-1. **Esperar CI verde** en PR #10 → mergear a `main`
-2. **Conectar repo a Cloudflare Pages** (tarea 1.10 aplazada del Sprint 1)
-3. **Comprar dominio** `futbolparaninos.club`
-4. **Diseñar logo MiniGol Club** (afecta E-E-A-T y branding)
-5. **Publicar OG image por defecto** `/og-default.jpg` (referenciada en BaseLayout, aún falta el asset)
+1. **Conectar repo a Cloudflare Pages** (tarea 1.10 aplazada del Sprint 1)
+2. **Comprar dominio** `futbolparaninos.club` (tarea 1.11)
+3. **Apuntar dominio a Cloudflare Pages, HTTPS activo** (tarea 1.12)
+4. **Publicar OG image por defecto** `/og-default.jpg` (referenciada en BaseLayout, aún falta el asset)
+5. **Diseñar logo MiniGol Club** (afecta E-E-A-T y branding)
 
 ---
 
@@ -45,7 +45,7 @@
 
 | Métrica | Objetivo año 1 | Actual | Última medición |
 |---------|----------------|--------|-----------------|
-| Artículos publicados | 50 | 1 (en PR) | 2026-04-25 |
+| Artículos publicados | 50 | 1 | 2026-04-25 |
 | Visitas/mes (GA4) | 30.000 | 0 | — |
 | Suscriptores newsletter | 1.000 | 0 | — |
 | Ingresos AdSense ($) | 200/mes | 0 | — |
@@ -55,10 +55,10 @@
 
 ---
 
-## 🔄 Sprint actual — Sprint 2 (semanas 3-4)
+## ✅ Sprint 2 cerrado — Layouts y content collections (semanas 3-4)
 
-### Objetivo
-Sistema editorial funcionando: crear un `.mdx` = artículo publicado con SEO completo.
+### Resultado
+Sistema editorial funcionando. Lighthouse CI verde en las 3 URLs de prueba (Perf ≥90, A11y ≥95, SEO=100, BP ≥90). Mergeado a `main` el 2026-04-25 (PR #10).
 
 ### Cerradas en este sprint
 - [x] 2.1 `content/config.ts` — schemas Zod (PR #10)
@@ -81,16 +81,36 @@ Sistema editorial funcionando: crear un `.mdx` = artículo publicado con SEO com
 - [ ] 2.5 `<CategoryHero>` como componente independiente — inline en `CategoryLayout` es suficiente por ahora
 - [ ] 2.14 OG image dinámica (Satori) — prioridad media, complejidad alta; entra en Sprint 3
 
-### Bloqueantes actuales
-- PR #10 pendiente de CI verde (fix de pnpm ya pusheado, esperando re-run)
-
 ### Notas / aprendizajes
 - Astro 5 cambió la API de render: `render(entry)` importado desde `astro:content`, no `entry.render()`
 - `pnpm/action-setup@v4` no acepta `version` si `packageManager` está en `package.json` — usar sin `version`
 - En TypeScript strict, los callbacks de `getCollection` necesitan tipo explícito `CollectionEntry<'nombre'>`
+- Lighthouse axe: `text-{color}` sobre `bg-{color}/10` falla WCAG 1.4.3 — usar siempre `text-foreground` en badges tintados
+- Lighthouse axe: opacity modifier `/70` en colores de texto reduce el ratio a ~3.5:1 — evitar opacidad en texto pequeño
+- Lighthouse CI usa viewport 375px: `hidden sm:block` oculta texto que `aria-label` menciona → `label-content-name-mismatch`
 
-### Siguiente sprint planificado
-Sprint 3 — SEO técnico + AdSense submit (ver `PlanTrabajo.md`)
+---
+
+## 🔄 Sprint actual — Sprint 3 (semanas 5-6)
+
+### Objetivo
+Sitio listo para crawl + solicitud AdSense enviada. Requiere deploy en producción primero (dominio + Cloudflare Pages).
+
+### Por hacer en este sprint
+- [ ] **1.10** Conectar repo a Cloudflare Pages (deploy automático en `main`)
+- [ ] **1.11** Comprar dominio `futbolparaninos.club`
+- [ ] **1.12** Apuntar dominio a Cloudflare Pages, HTTPS activo
+- [ ] **3.1** Verificar dominio en Google Search Console + Bing Webmaster
+- [ ] **3.2** Submit sitemap.xml en GSC + Bing
+- [ ] **3.3** Configurar GA4 + Cloudflare Web Analytics
+- [ ] **3.4** Banner consentimiento cookies (Consent Mode v2)
+- [ ] **3.5** Componente `<AdSlot>` con label "Publicidad" + placeholder
+- [ ] **3.7** Solicitar AdSense (con ≥10 artículos, ajustar si aún son menos)
+- [ ] **3.8** Solicitar Amazon Afiliados España
+- [ ] **3.11** Search interna con Pagefind + página `/buscar`
+- [ ] **3.12** Publicar 5 artículos más (total 6)
+- [ ] **3.13** Página /sobre/ con bio autor (E-E-A-T)
+- [ ] Asset `/public/og-default.jpg` (referenciado en BaseLayout, aún falta)
 
 ---
 

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -16,7 +16,7 @@ const {
 } = Astro.props;
 
 const { title, description, cover, coverAlt, coverWidth, coverHeight, pubDate, edadMin, edadMax, tiempoLectura } = article.data;
-const slug = `/articulos/${article.id}/`;
+const slug = `/${article.id.replace('.mdx', '')}/`;
 
 const colorMap: Record<string, string> = {
   primary: 'bg-primary/10 text-foreground',


### PR DESCRIPTION
## What changed

`ArticleCard` generaba URLs incorrectas del tipo `/articulos/entrenamiento/slug.mdx/` en lugar de `/entrenamiento/slug/`, haciendo que todos los links de artículo dieran 404.

La ruta correcta coincide con `[categoria]/[slug].astro`. La corrección usa `article.id.replace('.mdx', '')` que da exactamente esa ruta.

## Type of change
- [x] Bug fix

## How to test
1. `pnpm dev` → ir a `/entrenamiento/`
2. Hacer click en la tarjeta del artículo → debe cargar `/entrenamiento/ejercicios-futbol-ninos-6-anos/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)