### PR TITLE
feat: toggle de tema claro/oscuro/sistema

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,6 +2,7 @@
 import { NAV_PRIMARY, SITE } from '@/consts';
 import { Icon } from 'astro-icon/components';
 import Logo from '@/components/ui/Logo.astro';
+import ThemeToggle from '@/components/ui/ThemeToggle.astro';
 
 const currentPath = Astro.url.pathname;
 ---
@@ -59,6 +60,8 @@ const currentPath = Astro.url.pathname;
 
     <!-- Acciones -->
     <div class="flex items-center gap-2">
+      <ThemeToggle />
+
       <a
         href="/buscar/"
         class="flex h-11 w-11 items-center justify-center rounded-md transition-colors"

--- a/src/components/ui/ThemeToggle.astro
+++ b/src/components/ui/ThemeToggle.astro
@@ -1,0 +1,66 @@
+---
+import { Icon } from 'astro-icon/components';
+
+// Botón cíclico 3 estados: auto → light → dark → auto.
+// Persiste en localStorage como `mg.theme`. El bootstrap del tema vive en
+// BaseLayout (script anti-FOUC) — este componente solo cambia el estado
+// y mantiene el icono/label sincronizado.
+---
+
+<button
+  type="button"
+  id="theme-toggle"
+  class="flex h-11 w-11 items-center justify-center rounded-md transition-colors"
+  style="color: var(--color-foreground-muted);"
+  aria-label="Tema actual: automático. Pulsa para cambiar."
+  data-theme-state="auto"
+>
+  <Icon name="lucide:monitor" class="h-5 w-5" data-icon="auto" aria-hidden="true" />
+  <Icon name="lucide:sun" class="hidden h-5 w-5" data-icon="light" aria-hidden="true" />
+  <Icon name="lucide:moon" class="hidden h-5 w-5" data-icon="dark" aria-hidden="true" />
+</button>
+
+<script is:inline>
+  (function () {
+    var btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+
+    var ORDER = ['auto', 'light', 'dark'];
+    var LABELS = {
+      auto: 'Tema actual: automático (sigue tu sistema). Pulsa para cambiar a claro.',
+      light: 'Tema actual: claro. Pulsa para cambiar a oscuro.',
+      dark: 'Tema actual: oscuro. Pulsa para volver a automático.',
+    };
+
+    function readTheme() {
+      try {
+        var t = localStorage.getItem('mg.theme');
+        return t === 'light' || t === 'dark' || t === 'auto' ? t : 'auto';
+      } catch { return 'auto'; }
+    }
+
+    function applyIcon(theme) {
+      var icons = btn.querySelectorAll('[data-icon]');
+      for (var i = 0; i < icons.length; i++) {
+        icons[i].classList.toggle('hidden', icons[i].getAttribute('data-icon') !== theme);
+      }
+      btn.setAttribute('aria-label', LABELS[theme]);
+      btn.setAttribute('data-theme-state', theme);
+    }
+
+    function applyTheme(theme) {
+      try { localStorage.setItem('mg.theme', theme); } catch { /* sin persistencia, OK */ }
+      document.documentElement.setAttribute('data-theme', theme);
+      applyIcon(theme);
+    }
+
+    // Init: sincroniza icono con el estado real (que ya aplicó el bootstrap).
+    applyIcon(readTheme());
+
+    btn.addEventListener('click', function () {
+      var current = readTheme();
+      var next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
+      applyTheme(next);
+    });
+  })();
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -35,6 +35,23 @@ const fullTitle = title === SITE.name ? title : `${title} · ${SITE.name}`;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
+
+    <!-- Anti-FOUC theme bootstrap. Debe ejecutarse antes del primer paint:
+         lee localStorage (`mg.theme`) y aplica `data-theme` al <html>.
+         Si falta o vale 'auto', no añade atributo y el CSS sigue prefers-color-scheme. -->
+    <script is:inline>
+      (function () {
+        try {
+          var t = localStorage.getItem('mg.theme');
+          if (t === 'light' || t === 'dark') {
+            document.documentElement.setAttribute('data-theme', t);
+          } else if (t === 'auto' || t === null) {
+            document.documentElement.setAttribute('data-theme', 'auto');
+          }
+        } catch { /* localStorage no disponible: queda en auto */ }
+      })();
+    </script>
+
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
     <title>{fullTitle}</title>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -69,9 +69,10 @@
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* Dark mode automático por preferencia del sistema.
-   Los tokens de marca se aclaran (400-series) para superar 4.5:1 sobre
-   los fondos oscuros (#11151e / #181e2b / #232c3d). */
+/* Tokens dark mode. Aplicados en 2 escenarios:
+   - prefers-color-scheme:dark + data-theme=auto (o sin atributo)
+   - data-theme=dark explícito (override del usuario via toggle)
+   Brand 600→400 para garantizar WCAG 4.5:1 sobre #11151e/#181e2b/#232c3d. */
 @media (prefers-color-scheme: dark) {
   :root[data-theme='auto'],
   :root:not([data-theme]) {
@@ -95,7 +96,40 @@
     --color-fun: #f472b6;
     --color-energy: #f87171;
     --color-info: #22d3ee;
+    color-scheme: dark;
   }
+}
+
+/* Override explícito del usuario (toggle): data-theme='dark' fuerza dark mode
+   independientemente de prefers-color-scheme. */
+:root[data-theme='dark'] {
+  --color-background: #11151e;
+  --color-paper: #181e2b;
+  --color-surface: #1b2230;
+  --color-surface-alt: #232c3d;
+  --color-rule: #2a3344;
+  --color-rule-strong: #3a4556;
+  --color-foreground: #eceff6;
+  --color-foreground-muted: #c4cbdc;
+  --color-foreground-subtle: #a0a8bb;
+  --color-handwritten: #94b5ff;
+  --color-marker: #d4a02e;
+  --color-border: #2a3344;
+  --color-border-strong: #3a4556;
+  --color-primary: #60a5fa;
+  --color-primary-hover: #93c5fd;
+  --color-secondary: #4ade80;
+  --color-accent: #fbbf24;
+  --color-fun: #f472b6;
+  --color-energy: #f87171;
+  --color-info: #22d3ee;
+  color-scheme: dark;
+}
+
+/* data-theme='light' fuerza light mode, ignorando prefers-color-scheme.
+   Los tokens light son los del @theme inicial — solo necesitamos color-scheme. */
+:root[data-theme='light'] {
+  color-scheme: light;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- Botón en el Header (junto a buscar y menú) que cicla entre **automático → claro → oscuro → automático**.
- Persiste la elección en `localStorage` como `mg.theme`. La preferencia del usuario tiene prioridad sobre `prefers-color-scheme` del OS.
- Script anti-FOUC inline en `<head>` aplica el tema antes del primer paint — sin parpadeo al recargar.
- `color-scheme` nativo se aplica al `<html>` para que inputs, scrollbars y controles del navegador respeten también el tema.

## Cambios técnicos
- `src/components/ui/ThemeToggle.astro` (nuevo) — botón con 3 iconos Lucide (`monitor`/`sun`/`moon`), touch 44×44, aria-label dinámico ("Tema actual: X. Pulsa para cambiar a Y").
- `src/layouts/BaseLayout.astro` — bootstrap inline de `data-theme` antes del CSS.
- `src/styles/global.css` — bloque `:root[data-theme='dark']` con override explícito + `:root[data-theme='light']` con `color-scheme: light`.
- `src/components/Header.astro` — integra `<ThemeToggle />` antes del botón de búsqueda.

## Test plan
- [ ] Click en el botón cicla los 3 estados y el icono se sincroniza
- [ ] Recargar con `localStorage.mg.theme = 'dark'` muestra el sitio en oscuro **sin flash claro**
- [ ] Recargar con `localStorage.mg.theme = 'light'` muestra el sitio en claro aunque el OS esté en dark
- [ ] Quitar la entrada de localStorage → vuelve a `auto` y sigue al OS
- [ ] Botón touch ≥44×44 en mobile (verificable con DevTools)
- [ ] Lighthouse a11y permanece en 1.0 (verificado local: ✅)
- [ ] Lighthouse color-contrast permanece en 1.0 en ambos modos

## Verificación local
```
pnpm build
npx -y @lhci/cli@0.14.x autorun  # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)