### PR TITLE
fix(deps): cierra GHSA-48c2-rrv3-qjmp (yaml stack overflow)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
   "packageManager": "pnpm@10.33.2",
   "engines": {
     "node": ">=22.12.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "yaml": ">=2.8.3"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  yaml: '>=2.8.3'
+
 importers:
 
   .:
@@ -2719,7 +2722,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -2889,11 +2892,6 @@ packages:
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
-    hasBin: true
-
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
     hasBin: true
 
   yaml@2.8.3:
@@ -6231,9 +6229,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.8.3
 
   yaml@2.8.3: {}
 


### PR DESCRIPTION
## Summary
Cierra **Dependabot alert #2** — [CVE-2026-33532](https://nvd.nist.gov/vuln/detail/CVE-2026-33532) / [GHSA-48c2-rrv3-qjmp](https://github.com/eemeli/yaml/security/advisories/GHSA-48c2-rrv3-qjmp), severity **medium** (CVSS 4.3).

`yaml < 2.8.3` es vulnerable a stack overflow en la fase compose/resolve cuando recibe YAML con flow sequences profundamente anidadas (~1000-5000 niveles, ~2-10 KB). El fix corrige la recursión sin bound.

## Cadena de dependencia
```
@astrojs/check 0.9.8
└── @astrojs/language-server 2.16.6
    └── volar-service-yaml 0.0.70
        └── yaml-language-server 1.20.0
            └── yaml@2.7.1  ❌ vulnerable
```

## Riesgo real
**Bajo.** `yaml` se usa solo en build-time (`pnpm typecheck` vía `astro check`). No procesamos YAML controlado por usuario en runtime. Pero igual cerramos la alerta activa.

## Fix aplicado
`pnpm.overrides` en `package.json`:
```json
"pnpm": {
  "overrides": {
    "yaml": ">=2.8.3"
  }
}
```

Tras `pnpm install`, `pnpm why yaml` confirma una sola versión (2.8.3) en todo el árbol.

## Test plan
- [x] `pnpm install` regenera lockfile sin errores
- [x] `pnpm why yaml` → "Found 1 version of yaml" (2.8.3)
- [x] `pnpm typecheck` exit 0
- [x] `pnpm lint` exit 0
- [x] `pnpm build` exit 0
- [x] Lighthouse local `npx -y @lhci/cli@0.14.x autorun` exit 0
- [ ] CI verde en este PR
- [ ] Tras merge: alerta Dependabot #2 se marca como resuelta automáticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)