### PR TITLE
feat(admin): botón Publicar en EditPage → PR draft automático

### DIFF
--- a/admin/src/pages/EditPage.jsx
+++ b/admin/src/pages/EditPage.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, ExternalLink, Save } from 'lucide-react';
+import { ArrowLeft, ExternalLink, Save, Send } from 'lucide-react';
 import FrontmatterForm from '../components/FrontmatterForm.jsx';
 import MDXEditor from '../components/MDXEditor.jsx';
 import ValidationFooter from '../components/ValidationFooter.jsx';
 import { useArticulo } from '../hooks/useArticulos.js';
+import { publicarArticulo } from '../services/articulosAPI.js';
 import { validateArticulo } from '../services/schemaValidator.js';
 import { toast } from '../services/toast.js';
 
@@ -16,6 +17,8 @@ export default function EditPage() {
   const [frontmatter, setFrontmatter] = useState(null);
   const [body, setBody] = useState('');
   const [errors, setErrors] = useState({});
+  const [publishing, setPublishing] = useState(false);
+  const [prCreado, setPrCreado] = useState(null);
 
   // Inicializa estado local con los datos del API
   useEffect(() => {
@@ -38,6 +41,29 @@ export default function EditPage() {
     }
     setErrors({});
     save(cleanFm, body);
+  }
+
+  async function handlePublicar() {
+    if (!frontmatter) return;
+    const { _slug, _categoria, ...cleanFm } = frontmatter;
+    const { valid, errors: validationErrors } = validateArticulo(cleanFm);
+    if (!valid) {
+      setErrors(validationErrors);
+      toast('Corrige los errores antes de publicar', 'error');
+      return;
+    }
+    // Guardar cambios en disco antes de crear el PR
+    await save(cleanFm, body);
+    setPublishing(true);
+    try {
+      const result = await publicarArticulo(slug);
+      setPrCreado(result);
+      toast('PR draft abierto en GitHub', 'success');
+    } catch (err) {
+      toast(err.message, 'error');
+    } finally {
+      setPublishing(false);
+    }
   }
 
   function handleAudit() {
@@ -107,15 +133,33 @@ export default function EditPage() {
           </span>
         </div>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          {prCreado && (
+            <a
+              href={prCreado.prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 5,
+                fontSize: 12, fontFamily: 'var(--font-mono)',
+                color: 'var(--color-secondary)', fontWeight: 600,
+                textDecoration: 'none', padding: '4px 10px',
+                background: 'color-mix(in srgb, var(--color-secondary) 12%, transparent)',
+                borderRadius: 6,
+              }}
+            >
+              PR #{prCreado.prNumber} abierto
+              <ExternalLink size={12} />
+            </a>
+          )}
           <button
             className="btn btn-ghost"
             onClick={() => handleSave(true)}
-            disabled={saving}
+            disabled={saving || publishing}
             type="button"
           >
             <Save size={16} />
-            Guardar borrador
+            Borrador
           </button>
           <a
             href={`http://localhost:4321/${data?.categoria}/${slug}/`}
@@ -127,13 +171,23 @@ export default function EditPage() {
             <ExternalLink size={16} />
           </a>
           <button
-            className="btn btn-primary"
+            className="btn btn-ghost"
             onClick={() => handleSave(false)}
-            disabled={saving}
+            disabled={saving || publishing}
             type="button"
           >
             <Save size={16} />
-            {saving ? 'Guardando…' : 'Guardar publicado'}
+            {saving ? 'Guardando…' : 'Guardar'}
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handlePublicar}
+            disabled={saving || publishing || !!prCreado}
+            type="button"
+            title={prCreado ? 'PR ya abierto' : 'Guarda + abre PR draft en GitHub'}
+          >
+            <Send size={16} />
+            {publishing ? 'Abriendo PR…' : 'Publicar'}
           </button>
         </div>
       </div>

--- a/admin/src/services/articulosAPI.js
+++ b/admin/src/services/articulosAPI.js
@@ -25,6 +25,15 @@ export async function saveArticulo(slug, { frontmatter, body }) {
   return res.json();
 }
 
+export async function publicarArticulo(slug) {
+  const res = await fetch(`${BASE}/${slug}/publicar`, { method: 'POST' });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.ok === false) {
+    throw new Error(data.error || `Error ${res.status} al publicar`);
+  }
+  return data;
+}
+
 export async function deleteArticulo(slug) {
   const res = await fetch(`${BASE}/${slug}`, { method: 'DELETE' });
   const data = await res.json().catch(() => ({ ok: false, error: `Error ${res.status}` }));

--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -394,7 +394,7 @@ function articulosApiMiddleware() {
           let branchCreated = false;
           let branchName = '';
 
-          try {
+          (async () => { try {
             const articulos = readArticulosRecursive(ARTICULOS_DIR, ARTICULOS_DIR);
             const found = articulos.find((a) => a.slug === slug);
             if (!found) {
@@ -487,7 +487,7 @@ function articulosApiMiddleware() {
             }
             res.statusCode = 500;
             res.end(JSON.stringify({ ok: false, error: err.message }));
-          }
+          } })();
           return;
         }
 

--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -43,7 +43,7 @@ function articulosApiMiddleware() {
       server.middlewares.use('/api/articulos', (req, res, next) => {
         res.setHeader('Content-Type', 'application/json');
         res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Access-Control-Allow-Methods', 'GET, PUT, POST, OPTIONS');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, PUT, POST, DELETE, OPTIONS');
         res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 
         if (req.method === 'OPTIONS') {
@@ -382,6 +382,112 @@ function articulosApiMiddleware() {
               res.end(JSON.stringify({ ok: false, error: err.message }));
             }
           });
+          return;
+        }
+
+        // POST /api/articulos/:slug/publicar → worktree desde origin/main, commit solo el MDX+cover, PR draft
+        if (req.method === 'POST' && pathParts[1] === 'publicar') {
+          const slug = pathParts[0];
+          const repoRoot = path.join(__dirname, '..');
+          const worktreePath = path.join(repoRoot, '..', 'mg-pr-tmp');
+          let worktreeCreated = false;
+          let branchCreated = false;
+          let branchName = '';
+
+          try {
+            const articulos = readArticulosRecursive(ARTICULOS_DIR, ARTICULOS_DIR);
+            const found = articulos.find((a) => a.slug === slug);
+            if (!found) {
+              res.statusCode = 404;
+              res.end(JSON.stringify({ ok: false, error: 'Artículo no encontrado' }));
+              return;
+            }
+
+            const { categoria, filePath: articleFilePath, frontmatter } = found;
+            const relFilePath = `src/content/articulos/${categoria}/${slug}.mdx`;
+            const coverFilePath = path.join(repoRoot, 'src', 'assets', 'articulos', categoria, `${slug}.jpg`);
+            const relCoverPath = `src/assets/articulos/${categoria}/${slug}.jpg`;
+            const hasCover = fs.existsSync(coverFilePath);
+
+            branchName = `content/${slug}`;
+            const commitMsg = `content: añadir ${(frontmatter.title || slug).slice(0, 45)}`;
+
+            // Verificar que la branch no existe ya
+            try {
+              await execFileAsync('git', ['rev-parse', '--verify', branchName], { cwd: repoRoot });
+              res.statusCode = 409;
+              res.end(JSON.stringify({ ok: false, error: `Branch ya existe: ${branchName}` }));
+              return;
+            } catch { /* no existe — OK */ }
+            try {
+              await execFileAsync('git', ['ls-remote', '--exit-code', '--heads', 'origin', branchName], { cwd: repoRoot });
+              res.statusCode = 409;
+              res.end(JSON.stringify({ ok: false, error: `Branch ya existe en origin: ${branchName}` }));
+              return;
+            } catch { /* no existe — OK */ }
+
+            // Limpiar worktree si quedó de antes
+            if (fs.existsSync(worktreePath)) {
+              await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], { cwd: repoRoot });
+            }
+
+            // Worktree desde origin/main actualizado
+            await execFileAsync('git', ['fetch', 'origin', 'main'], { cwd: repoRoot });
+            await execFileAsync('git', ['worktree', 'add', '--no-checkout', worktreePath, 'origin/main'], { cwd: repoRoot });
+            worktreeCreated = true;
+
+            await execFileAsync('git', ['checkout', '-b', branchName], { cwd: worktreePath });
+            branchCreated = true;
+
+            // Copiar solo los archivos del artículo al worktree
+            const destMdx = path.join(worktreePath, relFilePath);
+            await fsp.mkdir(path.dirname(destMdx), { recursive: true });
+            await fsp.copyFile(articleFilePath, destMdx);
+
+            const filesToAdd = [relFilePath];
+            if (hasCover) {
+              const destCover = path.join(worktreePath, relCoverPath);
+              await fsp.mkdir(path.dirname(destCover), { recursive: true });
+              await fsp.copyFile(coverFilePath, destCover);
+              filesToAdd.push(relCoverPath);
+            }
+
+            await execFileAsync('git', ['add', ...filesToAdd], { cwd: worktreePath });
+            await execFileAsync('git', ['commit', '-m', commitMsg], { cwd: worktreePath });
+            await execFileAsync('git', ['push', '-u', 'origin', branchName], { cwd: worktreePath });
+
+            const prBody = [
+              `## Artículo: ${frontmatter.title || slug}`,
+              '',
+              `- **Categoría:** ${categoria}`,
+              `- **Keyword:** ${frontmatter.keyword || '—'}`,
+              `- **Edad:** ${frontmatter.edadMin}–${frontmatter.edadMax} años`,
+              `- **Nivel:** ${frontmatter.nivel || '—'}`,
+              '',
+              'Publicado desde el Content Manager (admin/) vía botón Publicar.',
+            ].join('\n');
+
+            const { stdout: prOut } = await execFileAsync(
+              'gh',
+              ['pr', 'create', '--base', 'main', '--head', branchName, '--title', commitMsg, '--body', prBody, '--draft'],
+              { cwd: worktreePath },
+            );
+
+            const prUrl = prOut.trim();
+            const prNumber = prUrl.match(/\/pull\/(\d+)$/)?.[1];
+
+            await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], { cwd: repoRoot });
+            res.end(JSON.stringify({ ok: true, branch: branchName, prUrl, prNumber: prNumber ? parseInt(prNumber, 10) : null }));
+          } catch (err) {
+            if (worktreeCreated && fs.existsSync(worktreePath)) {
+              try { await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], { cwd: repoRoot }); } catch { /* ignore */ }
+            }
+            if (branchCreated && branchName) {
+              try { await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoRoot }); } catch { /* ignore */ }
+            }
+            res.statusCode = 500;
+            res.end(JSON.stringify({ ok: false, error: err.message }));
+          }
           return;
         }
 


### PR DESCRIPTION
## Qué hace
Añade un botón **Publicar** en la página de edición del Content Manager que, con un solo clic:

1. Valida el frontmatter (Zod)
2. Guarda el archivo al disco (PUT)
3. Crea un worktree desde `origin/main` actualizado (sin contaminar el working tree)
4. Copia solo el `.mdx` y la cover (si existe) — nunca archivos extra
5. Hace commit + push + abre PR draft en GitHub
6. Muestra badge con link al PR en la topbar

## Por qué
Elimina la necesidad de ir a la terminal o a GitHub para publicar un artículo editado.
El flujo completo queda dentro del admin.

## Archivos cambiados
- `admin/vite.config.js` — nuevo endpoint `POST /api/articulos/:slug/publicar`
- `admin/src/services/articulosAPI.js` — función `publicarArticulo(slug)`
- `admin/src/pages/EditPage.jsx` — botón Publicar + badge PR