### PR TITLE
feat(i18n): selector idioma ES/CA en header de artículos

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,7 +3,13 @@ import { NAV_PRIMARY, SITE } from '@/consts';
 import { Icon } from 'astro-icon/components';
 import Logo from '@/components/ui/Logo.astro';
 import ThemeToggle from '@/components/ui/ThemeToggle.astro';
+import LangSwitcher from '@/components/ui/LangSwitcher.astro';
 
+interface Props {
+  hreflangs?: Array<{ lang: string; href: string }>;
+}
+
+const { hreflangs } = Astro.props;
 const currentPath = Astro.url.pathname;
 ---
 
@@ -60,6 +66,7 @@ const currentPath = Astro.url.pathname;
 
     <!-- Acciones -->
     <div class="flex items-center gap-2">
+      {hreflangs && <LangSwitcher hreflangs={hreflangs} />}
       <ThemeToggle />
 
       <a

--- a/src/components/ui/LangSwitcher.astro
+++ b/src/components/ui/LangSwitcher.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  hreflangs: Array<{ lang: string; href: string }>;
+}
+
+const { hreflangs } = Astro.props;
+const currentLang = Astro.currentLocale ?? 'es';
+
+const esHref = hreflangs.find((h) => h.lang === 'es')?.href;
+const caHref = hreflangs.find((h) => h.lang === 'ca')?.href;
+
+if (!esHref || !caHref) return;
+---
+
+<div
+  class="mono flex items-center text-xs"
+  style="gap: 2px; color: var(--color-foreground-muted); letter-spacing: 0.06em;"
+  aria-label="Cambiar idioma"
+>
+  <a
+    href={esHref}
+    hreflang="es"
+    aria-current={currentLang === 'es' ? 'true' : undefined}
+    style={currentLang === 'es'
+      ? 'color: var(--color-foreground); font-weight: 700;'
+      : 'color: var(--color-foreground-muted);'}
+    class="rounded px-1.5 py-0.5 transition-colors hover:opacity-80"
+  >ES</a>
+  <span aria-hidden="true" style="opacity: 0.25; font-weight: 300;">|</span>
+  <a
+    href={caHref}
+    hreflang="ca"
+    aria-current={currentLang === 'ca' ? 'true' : undefined}
+    style={currentLang === 'ca'
+      ? 'color: var(--color-foreground); font-weight: 700;'
+      : 'color: var(--color-foreground-muted);'}
+    class="rounded px-1.5 py-0.5 transition-colors hover:opacity-80"
+  >CA</a>
+</div>

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -108,7 +108,7 @@ const authorInitials = AUTHOR.name
     <meta name="pinterest:media" content={ogImageUrl} />
   </Fragment>
 
-  <Header />
+  <Header hreflangs={hreflangs} />
 
   <div class="mx-auto max-w-5xl px-4 md:px-6">
     <Breadcrumb

--- a/src/pages/[categoria]/[slug].astro
+++ b/src/pages/[categoria]/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, getEntry, render, type CollectionEntry } from 'astro:content';
 import ArticleLayout from '@/layouts/ArticleLayout.astro';
+import { SITE_URL } from '@/consts';
 
 export async function getStaticPaths() {
   const articulos = await getCollection(
@@ -21,6 +22,27 @@ const { article } = Astro.props as { article: CollectionEntry<'articulos'> };
 const { Content, headings } = await render(article);
 
 const categoria = await getEntry('categorias', article.data.categoria);
+
+const esSlug = (article.id.split('/').pop() ?? article.id).replace(/\.mdx?$/, '');
+const articulosCa = await getCollection(
+  'articulos-ca',
+  ({ data }: CollectionEntry<'articulos-ca'>) => !data.draft
+);
+const caArticle = articulosCa.find(
+  (a: CollectionEntry<'articulos-ca'>) => a.data.traduccionDe === esSlug
+);
+
+let hreflangs: Array<{ lang: string; href: string }> | undefined;
+if (caArticle) {
+  const caSlug = (caArticle.id.split('/').pop() ?? caArticle.id).replace(/\.mdx?$/, '');
+  const esUrl = new URL(`/${article.data.categoria}/${esSlug}/`, SITE_URL).toString();
+  const caUrl = new URL(`/ca/${caArticle.data.categoria}/${caSlug}/`, SITE_URL).toString();
+  hreflangs = [
+    { lang: 'es', href: esUrl },
+    { lang: 'ca', href: caUrl },
+    { lang: 'x-default', href: esUrl },
+  ];
+}
 
 const allArticulos = await getCollection(
   'articulos',
@@ -47,6 +69,7 @@ const relatedArticles = allArticulos
   categoriaColor={categoria?.data.color ?? 'secondary'}
   relatedArticles={relatedArticles}
   headings={headings}
+  hreflangs={hreflangs}
 >
   <Content />
 </ArticleLayout>


### PR DESCRIPTION
## Summary
- Añade componente `LangSwitcher` (pills ES | CA) en el header
- Visible solo en artículos que tienen traducción en la otra lengua
- Página ES detecta automáticamente si existe un artículo en `articulos-ca` con `traduccionDe` apuntando al slug actual
- Página CA ya tenía `hreflangs` — ahora los usa también para el switcher visual

## Test plan
- [ ] Abrir `/ejercicios/ejercicios-futbol-4-anos-sin-material/` → ver ES activo + link CA
- [ ] Seguir link CA → `/ca/ejercicios/exercicis-futbol-4-anys-sense-material/` → ver CA activo + link ES
- [ ] Abrir cualquier artículo sin traducción → switcher no aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)