### PR TITLE
feat(i18n): selector ES/CA siempre visible en el header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -80,7 +80,7 @@ const navLabelKey: Record<string, 'nav-ejercicios' | 'nav-juegos' | 'nav-equipam
 
     <!-- Acciones -->
     <div class="flex items-center gap-2">
-      {hreflangs && <LangSwitcher hreflangs={hreflangs} />}
+      <LangSwitcher hreflangs={hreflangs} />
       <ThemeToggle />
 
       <a

--- a/src/components/ui/LangSwitcher.astro
+++ b/src/components/ui/LangSwitcher.astro
@@ -1,21 +1,23 @@
 ---
 interface Props {
-  hreflangs: Array<{ lang: string; href: string }>;
+  hreflangs?: Array<{ lang: string; href: string }>;
 }
 
 const { hreflangs } = Astro.props;
 const currentLang = Astro.currentLocale ?? 'es';
 
-const esHref = hreflangs.find((h) => h.lang === 'es')?.href;
-const caHref = hreflangs.find((h) => h.lang === 'ca')?.href;
-
-if (!esHref || !caHref) return;
+// Si la página declara hreflangs explícitos (ej. artículo con traducción
+// pareada) usamos esos URLs precisos. Si no, fallback a la home del otro
+// idioma — siempre garantiza que el switcher sea funcional, no solo
+// visible en pares ya traducidos.
+const esHref = hreflangs?.find((h) => h.lang === 'es')?.href ?? '/';
+const caHref = hreflangs?.find((h) => h.lang === 'ca')?.href ?? '/ca/';
 ---
 
 <div
   class="mono flex items-center text-xs"
   style="gap: 2px; color: var(--color-foreground-muted); letter-spacing: 0.06em;"
-  aria-label="Cambiar idioma"
+  aria-label="Cambiar idioma / Canviar idioma"
 >
   <a
     href={esHref}


### PR DESCRIPTION
## Problema
El switcher ES/CA solo aparecía en páginas con \`hreflangs\` (artículos con traducción pareada). En la home (\`/\`), categorías, \`/sobre/\`, etc. **el switcher estaba oculto**, así que un visitante en castellano no descubría que existía versión catalana.

## Solución
\`<LangSwitcher>\` ahora es always-visible:
- **Si la página declara \`hreflangs\`** (artículo traducido) → usa esos URLs precisos
- **Si no** (resto del sitio) → fallback a la home del otro idioma (\`/ca/\` desde ES, \`/\` desde CA)

## Test plan
- [ ] Abrir home \`/\` → ver switcher \`ES | CA\` con ES activo
- [ ] Clic en CA → llega a \`/ca/\`
- [ ] Abrir cualquier página sin traducción (\`/sobre/\`, \`/recursos/\`, categoría) → switcher visible y funcional
- [ ] Abrir artículo CON traducción → switcher mantiene URLs precisas (no fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)