### PR TITLE
feat(social): scheduler automatizado a redes via Publer + GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
     branches: [main]
 
 jobs:
+  social-calendar:
+    name: Social Calendar Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - run: node scripts/social/validate-calendar.mjs
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest

--- a/.github/workflows/social-scheduler.yml
+++ b/.github/workflows/social-scheduler.yml
@@ -1,0 +1,75 @@
+name: Social Scheduler
+
+# Lee content/social/calendar.json, encuentra posts approved cuyo
+# scheduled_at cae dentro de la ventana actual, los envía a Publer
+# para programar/publicar y commitea el calendario actualizado.
+#
+# Cron cada 30 minutos. La ventana del scheduler debe ser >= intervalo
+# del cron para no perder posts (default 30min).
+
+on:
+  schedule:
+    # Cada 30min UTC. Ajustar si Publer satura o queremos menos requests.
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Solo loggear, no llamar a Publer ni commitear'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write  # necesario para commitear el calendar.json actualizado
+
+concurrency:
+  group: social-scheduler
+  cancel-in-progress: false
+
+jobs:
+  schedule:
+    name: Run scheduler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # token con permisos de write para que el push posterior funcione
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Validar calendar.json
+        run: node scripts/social/validate-calendar.mjs
+
+      - name: Ejecutar scheduler
+        env:
+          PUBLER_API_KEY: ${{ secrets.PUBLER_API_KEY }}
+          PUBLER_WORKSPACE_ID: ${{ secrets.PUBLER_WORKSPACE_ID }}
+          PUBLER_ACCOUNT_INSTAGRAM: ${{ secrets.PUBLER_ACCOUNT_INSTAGRAM }}
+          PUBLER_ACCOUNT_TIKTOK: ${{ secrets.PUBLER_ACCOUNT_TIKTOK }}
+          PUBLER_ACCOUNT_PINTEREST: ${{ secrets.PUBLER_ACCOUNT_PINTEREST }}
+          PUBLER_ACCOUNT_FACEBOOK: ${{ secrets.PUBLER_ACCOUNT_FACEBOOK }}
+          PUBLER_ACCOUNT_X: ${{ secrets.PUBLER_ACCOUNT_X }}
+          PUBLER_ACCOUNT_LINKEDIN: ${{ secrets.PUBLER_ACCOUNT_LINKEDIN }}
+          PUBLER_ACCOUNT_YOUTUBE: ${{ secrets.PUBLER_ACCOUNT_YOUTUBE }}
+          ASSETS_BASE_URL: ${{ vars.ASSETS_BASE_URL }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            node scripts/social/scheduler.mjs --dry-run
+          else
+            node scripts/social/scheduler.mjs
+          fi
+
+      - name: Commit cambios en calendar.json
+        if: ${{ inputs.dry_run != true }}
+        run: |
+          if git diff --quiet content/social/calendar.json; then
+            echo "Sin cambios — nada que commitear."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add content/social/calendar.json
+          git commit -m "chore(social): scheduler $(date -u +%Y-%m-%dT%H:%MZ) — actualizar status"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ Sitio de contenido SEO sobre fútbol infantil para padres con hijos de 4 a 12 a�
 - [docs/ArquitecturaPizarra.md](docs/ArquitecturaPizarra.md) — isla Preact, backend Cloudflare-only, freemium "motor gratis + entregables PRO", Lemon Squeezy, schema HowTo, A11y, topología `src/components/pizarra/`, bugs del mockup a corregir, ADR-006 borrador
 - [docs/PlanTrabajoPizarra.md](docs/PlanTrabajoPizarra.md) — Fase 2 (MVP gratis, ~24h), Fase 2.5 (URLs evergreen por preset), Fase 3a/b/c (cuentas, pagos, PDF/oEmbed) con criterios de avance entre fases
 
+**Redes sociales (scheduler automatizado):**
+- [docs/SchedulerPubler.md](docs/SchedulerPubler.md) — sistema GitHub Actions + Publer API + JSON versionado. Source of truth: [content/social/calendar.json](content/social/calendar.json). Cron cada 30min lee posts approved y los programa en Publer.
+- [docs/seo/EstrategiaSocialVideo.md](docs/seo/EstrategiaSocialVideo.md) — estrategia de contenido (Reels, hashtags, cadencia, integración Pizarra)
+
 **Estado vivo:**
 - [docs/PlanTrabajo.md](docs/PlanTrabajo.md) — backlog en sprints
 - [docs/FlujoTrabajo.md](docs/FlujoTrabajo.md) — qué se está haciendo ahora

--- a/content/social/calendar.json
+++ b/content/social/calendar.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "./calendar.schema.json",
+  "version": 1,
+  "generated_at": null,
+  "posts": [
+    {
+      "id": "2026-05-04-ig-exercicis-6-anys",
+      "platforms": ["instagram"],
+      "format": "carousel",
+      "scheduled_at": "2026-05-04T09:00:00+02:00",
+      "status": "draft",
+      "locale": "ca",
+      "article_slug": "exercicis-futbol-6-anys",
+      "target_url": "https://minigolclub.com/ca/ejercicios/exercicis-futbol-6-anys/?utm_source=instagram&utm_medium=carousel&utm_campaign=exercicis-futbol-6-anys",
+      "caption": "3 exercicis perquè el teu fill de 6 anys s'enganxi al futbol — ho pots fer al pati o al parc, sense material extra.\n\nGuia completa al link de la bio 👆",
+      "hashtags": [
+        "futbolinfantil",
+        "futbolcatalà",
+        "pares",
+        "entrenarafillsenfutbol",
+        "futbolcatalunya",
+        "escoladefutbol",
+        "futbolnens",
+        "esportencatalà"
+      ],
+      "media": [
+        {
+          "type": "image",
+          "path": "public/social/exercicis-futbol-6-anys/slide-1.jpg",
+          "alt": "Portada — 3 exercicis de futbol per a nens de 6 anys"
+        }
+      ],
+      "notes": "Hook: 'Si el teu fill de 6 anys es queda parat amb la pilota...'  Carrusel 5 slides: portada + 3 exercicis + CTA",
+      "published_at": null,
+      "publer_post_id": null
+    },
+    {
+      "id": "2026-05-06-ig-talla-pilota",
+      "platforms": ["instagram"],
+      "format": "single_image",
+      "scheduled_at": "2026-05-06T18:30:00+02:00",
+      "status": "draft",
+      "locale": "ca",
+      "article_slug": "talla-pilota-futbol-segons-edat",
+      "target_url": "https://minigolclub.com/ca/equipamiento/talla-pilota-futbol-segons-edat/?utm_source=instagram&utm_medium=feed&utm_campaign=talla-pilota",
+      "caption": "Quina talla de pilota necessita el teu fill segons l'edat? Guia ràpida per no equivocar-te.\n\nGuia completa al link de la bio 👆",
+      "hashtags": [
+        "futbolinfantil",
+        "pilotadefutbol",
+        "pares",
+        "futbolcatalunya",
+        "equipamentfutbol",
+        "tallapilota",
+        "regaldenadal"
+      ],
+      "media": [
+        {
+          "type": "image",
+          "path": "public/social/talla-pilota-futbol-segons-edat/feed.jpg",
+          "alt": "Tabla edad → talla de pilota de futbol"
+        }
+      ],
+      "notes": "Imagen estática tipo tabla. Generar con Satori desde el frontmatter del artículo si es posible.",
+      "published_at": null,
+      "publer_post_id": null
+    },
+    {
+      "id": "2026-05-08-ig-10-jocs",
+      "platforms": ["instagram"],
+      "format": "reel",
+      "scheduled_at": "2026-05-08T19:00:00+02:00",
+      "status": "draft",
+      "locale": "ca",
+      "article_slug": "10-jocs-futbol-divertits-facils",
+      "target_url": "https://minigolclub.com/ca/juegos/10-jocs-futbol-divertits-facils/?utm_source=instagram&utm_medium=reel&utm_campaign=10-jocs",
+      "caption": "10 jocs de futbol per fer al parc — sense entrenadors, sense pressió, només divertir-se.\n\nLlista completa al link de la bio 👆",
+      "hashtags": [
+        "futbolinfantil",
+        "jocsdefutbol",
+        "pares",
+        "futbolcatalunya",
+        "futbolalparc",
+        "nensifutbol",
+        "esportenfamília"
+      ],
+      "media": [
+        {
+          "type": "video",
+          "path": "public/social/10-jocs-futbol-divertits-facils/reel.mp4",
+          "alt": "Reel de 30s mostrando 3 jocs de futbol"
+        }
+      ],
+      "notes": "Reel piloto. Producir con CapCut. Subtítulos quemados. Sin caras de menores.",
+      "published_at": null,
+      "publer_post_id": null
+    }
+  ]
+}

--- a/content/social/calendar.schema.json
+++ b/content/social/calendar.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MiniGol Club — Social Calendar",
+  "description": "Calendario editorial de publicaciones a redes sociales. Source of truth versionada en Git. El scheduler de GitHub Actions lee este archivo, filtra los posts approved cuyo scheduled_at ya llegó, los publica via Publer y actualiza status a published.",
+  "type": "object",
+  "required": ["version", "posts"],
+  "properties": {
+    "version": { "type": "integer", "const": 1 },
+    "generated_at": { "type": ["string", "null"], "format": "date-time" },
+    "posts": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/post" }
+    }
+  },
+  "definitions": {
+    "post": {
+      "type": "object",
+      "required": [
+        "id",
+        "platforms",
+        "format",
+        "scheduled_at",
+        "status",
+        "locale",
+        "caption",
+        "media"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z]{2,5}-[a-z0-9-]+$",
+          "description": "Convención: YYYY-MM-DD-<plataforma>-<slug-corto>. Único."
+        },
+        "platforms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": ["instagram", "facebook", "tiktok", "x", "linkedin", "pinterest", "youtube"]
+          }
+        },
+        "format": {
+          "enum": ["single_image", "carousel", "reel", "story", "video", "text"]
+        },
+        "scheduled_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 con timezone (recomendado +02:00 Madrid)"
+        },
+        "status": {
+          "enum": ["draft", "approved", "published", "failed", "archived"],
+          "description": "draft = en construcción · approved = listo para publicar · published = ya enviado · failed = error en último intento · archived = no publicar"
+        },
+        "locale": {
+          "enum": ["es", "ca"]
+        },
+        "article_slug": {
+          "type": ["string", "null"],
+          "description": "Slug del artículo del sitio al que apunta (sin /). Opcional."
+        },
+        "target_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL final con UTM. Si vacía, el post no enlaza."
+        },
+        "caption": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2200,
+          "description": "Texto del post. Instagram máx 2200 chars."
+        },
+        "hashtags": {
+          "type": "array",
+          "maxItems": 30,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_à-ÿ]+$"
+          }
+        },
+        "media": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "type": "object",
+            "required": ["type", "path"],
+            "properties": {
+              "type": { "enum": ["image", "video"] },
+              "path": {
+                "type": "string",
+                "description": "Path relativo desde la raíz del repo. Sube a R2/CDN o usa raw GitHub para Publer."
+              },
+              "alt": { "type": "string" }
+            }
+          }
+        },
+        "notes": {
+          "type": "string",
+          "description": "Notas internas del editor. No se publica."
+        },
+        "published_at": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Set automático por el scheduler tras éxito"
+        },
+        "publer_post_id": {
+          "type": ["string", "null"],
+          "description": "ID Publer devuelto. Útil para debugging."
+        },
+        "error": {
+          "type": ["string", "null"],
+          "description": "Último mensaje de error si status=failed"
+        }
+      }
+    }
+  }
+}

--- a/docs/SchedulerPubler.md
+++ b/docs/SchedulerPubler.md
@@ -40,10 +40,10 @@ git commit "chore(social): scheduler ... — actualizar status"
 
 ### 1. Crear cuenta Publer y conectar redes
 
-1. Cuenta business en [publer.io](https://publer.io)
-2. **Settings → Workspaces** — crear "MiniGol Club" (o usar el default), copiar **Workspace ID** (formato UUID).
-3. **Accounts** — conectar `@minigolclub` Instagram, Pinterest, TikTok... según las que vayas a usar.
-4. **Settings → Developer API** — generar **API Key** (Bearer-Api token).
+1. Cuenta **Business** en [publer.com](https://publer.com) — el plan Professional NO incluye API access. Hay trial gratis 14 días.
+2. **Workspace ID:** consíguelo via API (ver paso 2 abajo) o desde la URL del workspace en la UI.
+3. **Accounts** — conectar `@minigolclub` Instagram (debe ser cuenta Creator o Business, no Personal). Publer redirige a Facebook OAuth porque Instagram requiere conexión via Facebook Page.
+4. **Settings → Access & Login → Manage API Keys → Generate API Key** — scopes: Workspaces, Accounts, Posts (write), Media (write). Copia la key INMEDIATAMENTE (solo se muestra 1 vez).
 
 ### 2. Descubrir account IDs
 
@@ -67,7 +67,7 @@ Salida esperada:
 
 | Secret | Valor |
 |--------|-------|
-| `PUBLER_API_KEY` | El token Bearer-Api del paso 1 |
+| `PUBLER_API_KEY` | El token Bearer-API del paso 1 |
 | `PUBLER_WORKSPACE_ID` | El UUID del workspace |
 | `PUBLER_ACCOUNT_INSTAGRAM` | Account ID de @minigolclub |
 | `PUBLER_ACCOUNT_TIKTOK` | (opcional) Account ID TikTok |

--- a/docs/SchedulerPubler.md
+++ b/docs/SchedulerPubler.md
@@ -1,0 +1,196 @@
+# Scheduler Publer — guía de uso
+
+> Sistema de publicación programada a redes sociales. Source of truth: `content/social/calendar.json`.
+> Inspirado en el repo `victorialozano0/LOVEYOURSELFJOURNAL` adaptado a nuestro stack
+> (GitHub Actions + JSON versionado en Git, sin app local con `localStorage`).
+
+---
+
+## Arquitectura
+
+```
+content/social/calendar.json   ← editor (humano) escribe aquí, status: draft → approved
+        │
+        ▼
+.github/workflows/social-scheduler.yml
+        │  cada 30 min
+        ▼
+scripts/social/scheduler.mjs
+        │  filtra approved con scheduled_at en ventana
+        ▼
+scripts/social/publer-client.mjs
+        │  POST /api/v1/posts/schedule/publish
+        ▼
+Publer API → distribuye a Instagram/TikTok/Pinterest/...
+        │
+        ▼
+git commit "chore(social): scheduler ... — actualizar status"
+        (status: approved → published / failed)
+```
+
+**Decisiones clave:**
+- **JSON en Git como source of truth.** No `localStorage`, no DB. Cada cambio audita por git log y revisa por PR.
+- **Aprobación humana = merge a main.** No hay toggle "publish now" — un post solo se publica si está `status: approved` y mergeado.
+- **Publer como capa de publicación.** Evita meses de aprobación oficial Meta/TikTok. ~15€/mes.
+- **Assets en el repo + raw GitHub.** Mientras no haya CDN propio, las imágenes/vídeos del calendar viven en `public/social/...` y Publer las descarga vía `raw.githubusercontent.com`.
+
+---
+
+## Setup inicial (una vez)
+
+### 1. Crear cuenta Publer y conectar redes
+
+1. Cuenta business en [publer.io](https://publer.io)
+2. **Settings → Workspaces** — crear "MiniGol Club" (o usar el default), copiar **Workspace ID** (formato UUID).
+3. **Accounts** — conectar `@minigolclub` Instagram, Pinterest, TikTok... según las que vayas a usar.
+4. **Settings → Developer API** — generar **API Key** (Bearer-Api token).
+
+### 2. Descubrir account IDs
+
+Cada red social conectada tiene un Account ID interno de Publer. Para descubrirlos:
+
+```bash
+PUBLER_API_KEY=tu_token PUBLER_WORKSPACE_ID=tu_workspace_id pnpm social:accounts
+```
+
+Salida esperada:
+
+```
+  • [instagram ] @minigolclub  →  64a1f9...
+  • [tiktok    ] @minigolclub  →  64a200...
+  • [pinterest ] minigolclub   →  64a201...
+```
+
+### 3. Configurar secrets en GitHub
+
+`Settings → Secrets and variables → Actions → New repository secret`:
+
+| Secret | Valor |
+|--------|-------|
+| `PUBLER_API_KEY` | El token Bearer-Api del paso 1 |
+| `PUBLER_WORKSPACE_ID` | El UUID del workspace |
+| `PUBLER_ACCOUNT_INSTAGRAM` | Account ID de @minigolclub |
+| `PUBLER_ACCOUNT_TIKTOK` | (opcional) Account ID TikTok |
+| `PUBLER_ACCOUNT_PINTEREST` | (opcional) |
+| `PUBLER_ACCOUNT_FACEBOOK` | (opcional) |
+| `PUBLER_ACCOUNT_X` | (opcional) |
+| `PUBLER_ACCOUNT_LINKEDIN` | (opcional) |
+| `PUBLER_ACCOUNT_YOUTUBE` | (opcional) |
+
+`Variables` (públicas, no secretos):
+
+| Variable | Valor por defecto | Uso |
+|----------|-------------------|-----|
+| `ASSETS_BASE_URL` | (vacío → usa raw.githubusercontent) | Si tienes CDN propio (Cloudflare R2, Bunny CDN), pon aquí la URL base de los assets |
+
+### 4. Verificar local (opcional)
+
+```bash
+pnpm social:validate              # valida calendar.json contra schema
+pnpm social:dry                   # corre el scheduler sin tocar Publer ni JSON
+```
+
+---
+
+## Flujo editorial diario
+
+### Crear un nuevo post
+
+1. Genera o sube el asset a `public/social/<slug-articulo>/<archivo>.{jpg,mp4}`
+2. Edita `content/social/calendar.json` añadiendo un objeto al array `posts`:
+
+```json
+{
+  "id": "2026-05-10-ig-jocs-aniversaris",
+  "platforms": ["instagram"],
+  "format": "carousel",
+  "scheduled_at": "2026-05-10T19:00:00+02:00",
+  "status": "draft",
+  "locale": "ca",
+  "article_slug": "jocs-futbol-aniversaris-nens",
+  "target_url": "https://minigolclub.com/ca/juegos/jocs-futbol-aniversaris-nens/?utm_source=instagram&utm_medium=carousel&utm_campaign=jocs-aniversaris",
+  "caption": "10 jocs de futbol per a l'aniversari del teu fill — sense crits, sense pares competint, només divertir-se.\n\nLlista completa al link de la bio 👆",
+  "hashtags": ["futbolinfantil", "aniversari", "festainfantil", "futbolcatalunya", "pares"],
+  "media": [
+    { "type": "image", "path": "public/social/jocs-aniversaris/slide-1.jpg", "alt": "10 jocs aniversari" }
+  ],
+  "notes": "Carrusel 10 slides, uno por joc. Color marca naranja.",
+  "published_at": null,
+  "publer_post_id": null
+}
+```
+
+3. **Convención de `id`:** `YYYY-MM-DD-<plataforma>-<slug-corto>` — único, kebab-case.
+4. **`scheduled_at`:** ISO 8601 con timezone (`+02:00` Madrid en verano, `+01:00` invierno).
+5. **`status: "draft"`** — el scheduler IGNORA los drafts. Solo publica `approved`.
+6. Valida en local: `pnpm social:validate`.
+
+### Aprobar y publicar
+
+1. Cuando esté listo, cambia `"status": "draft"` → `"status": "approved"`.
+2. Commit + PR + merge a `main`.
+3. En el siguiente cron (max 30min) el workflow lo programará en Publer.
+4. Tras éxito, el bot commiteará el cambio: `status: approved` → `published`, con `published_at` y `publer_post_id` rellenados.
+5. Si falla, `status: failed` con `error` describiendo el motivo. Editor revisa, corrige y re-aprueba.
+
+### Cancelar un post programado
+
+1. En GitHub, edita el JSON: `status` → `archived`.
+2. Si Publer YA tiene el post programado (`publer_post_id` existe), bórralo manualmente desde el dashboard de Publer.
+
+### Forzar ejecución del scheduler
+
+Sin esperar al cron:
+
+`Actions → Social Scheduler → Run workflow → branch: main → Run workflow`
+
+Marca `dry_run: true` si solo quieres loggear sin tocar Publer.
+
+---
+
+## Estrategia horaria (adaptada del POSTING_STRATEGY de LYJ)
+
+Audiencia objetivo: padres 30-45 en España y LATAM.
+
+| Plataforma | Mejores ventanas (Madrid TZ) | Frecuencia recomendada inicio |
+|------------|------------------------------|-------------------------------|
+| Instagram Reels | Mar/Jue/Sáb 19:00–21:00 | 1-2/semana |
+| Instagram Carousel | Lun/Mié/Vie 18:00–20:00 | 1/semana |
+| Instagram Story | Diario 09:00 ó 21:00 | 3-5/semana |
+| TikTok | Mar/Jue 20:00–22:00 | 1-2/semana |
+| Pinterest | Sáb/Dom mañana 10:00–12:00 | 2-3/semana |
+
+Ajustar tras 4 semanas con datos reales del Insights de cada plataforma.
+
+---
+
+## Costes
+
+| Item | Coste mensual |
+|------|---------------|
+| Publer Business (3 cuentas, posts ilimitados) | ~15€ |
+| GitHub Actions minutos (estimado <30 min/mes) | gratis (free tier 2000 min/mes) |
+| Cloudflare Workers (futuro: trending detector) | gratis (100k req/día free tier) |
+| Storage assets (raw GitHub) | gratis hasta volumen alto |
+
+---
+
+## Próximas iteraciones
+
+- **Validación CI en PR**: añadir `pnpm social:validate` al workflow `ci.yml` para que cada PR que toque `calendar.json` valide schema antes de mergear.
+- **Generador de imágenes sociales con Satori**: script `scripts/social/generate-image.mjs` que toma un slug de artículo y genera la imagen 1080×1080 con cover + título + branding.
+- **Worker Cron de tendencias**: replicar `bts-trending` de LYJ para detectar trending hashtags de futbol infantil y notificar al editor.
+- **Vista web del calendar**: página interna `/admin/social/` que renderiza el JSON como timeline visual (no necesario para v1).
+
+---
+
+## Troubleshooting
+
+**"Publer schedulePost: no jobId en respuesta"**
+La API devolvió 200 pero sin job ID — probablemente la cuenta de Publer no tiene permisos para esa plataforma o el account ID es incorrecto. Verifica con `pnpm social:accounts`.
+
+**"stale post ... — marcando failed"**
+El post quedó `approved` con `scheduled_at` >30min en el pasado al evaluar. Posible causa: workflow desactivado por GitHub (los crons en repos públicos sin actividad >60 días se pausan automáticamente). Solución: re-aprobar con nueva fecha futura, o ajustar `--window` si hay outage prolongado.
+
+**Workflow no ejecuta automáticamente**
+GitHub pausa crons en repos sin commits durante 60 días. Cualquier commit a main lo reactiva. Para repos privados con plan free tampoco corren workflows si superas la cuota mensual de minutos.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,11 @@ const nodeGlobals = {
   clearTimeout: 'readonly',
   URL: 'readonly',
   URLSearchParams: 'readonly',
+  // Node 22+ globals
+  fetch: 'readonly',
+  Response: 'readonly',
+  Request: 'readonly',
+  Headers: 'readonly',
 };
 
 export default [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "format": "prettier --write \"**/*.{ts,tsx,astro,md,mdx,css,json}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx,astro,md,mdx,css,json}\""
+    "format:check": "prettier --check \"**/*.{ts,tsx,astro,md,mdx,css,json}\"",
+    "social:validate": "node scripts/social/validate-calendar.mjs",
+    "social:dry": "node scripts/social/scheduler.mjs --dry-run",
+    "social:accounts": "node scripts/social/list-accounts.mjs"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",

--- a/scripts/social/list-accounts.mjs
+++ b/scripts/social/list-accounts.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * list-accounts.mjs
+ *
+ * Lista las cuentas conectadas en el workspace de Publer. Útil al
+ * configurar por primera vez para descubrir los account IDs que hay
+ * que poner en los secrets PUBLER_ACCOUNT_<PLATFORM>.
+ *
+ * Uso:
+ *   PUBLER_API_KEY=... PUBLER_WORKSPACE_ID=... pnpm social:accounts
+ */
+
+import { createPublerClient } from './publer-client.mjs';
+
+const apiKey = process.env.PUBLER_API_KEY;
+const workspaceId = process.env.PUBLER_WORKSPACE_ID;
+
+if (!apiKey || !workspaceId) {
+  console.error('❌ Necesito PUBLER_API_KEY y PUBLER_WORKSPACE_ID en el entorno.');
+  console.error('   Ej: PUBLER_API_KEY=xxx PUBLER_WORKSPACE_ID=yyy pnpm social:accounts');
+  process.exit(1);
+}
+
+const client = createPublerClient({
+  apiKey,
+  workspaceId,
+  // Truco: sin accountIds reales solo para que el constructor no falle.
+  accountIds: { _: '_' },
+});
+
+const accounts = await client.listAccounts();
+console.log('Cuentas conectadas en el workspace:\n');
+const list = Array.isArray(accounts) ? accounts : (accounts?.accounts ?? []);
+for (const a of list) {
+  const id = a.id ?? a._id ?? '?';
+  const provider = a.provider ?? a.network ?? '?';
+  const name = a.name ?? a.username ?? a.handle ?? '?';
+  console.log(`  • [${provider.padEnd(10)}] ${name}  →  ${id}`);
+}
+console.log(`\nTotal: ${list.length}`);
+console.log(`\nCopia el ID en el secret correspondiente:`);
+console.log(`  PUBLER_ACCOUNT_INSTAGRAM=<id>   (para instagram)`);
+console.log(`  PUBLER_ACCOUNT_TIKTOK=<id>      (para tiktok)`);
+console.log(`  ...`);

--- a/scripts/social/publer-client.mjs
+++ b/scripts/social/publer-client.mjs
@@ -3,8 +3,8 @@
  *
  * Cliente mínimo de la API de Publer v1 para programar posts a redes sociales.
  *
- * Auth: Bearer-Api token + Workspace ID en cabeceras.
- * Docs: https://app.publer.io/api-docs (requiere cuenta business).
+ * Auth: Bearer-API token + Workspace ID en cabeceras.
+ * Docs: https://publer.com/docs (requiere cuenta business para API access).
  *
  * Uso:
  *   import { createPublerClient } from './publer-client.mjs';
@@ -16,7 +16,7 @@
  * (scheduler.mjs) decide cómo manejar errores y rate limits.
  */
 
-const BASE = 'https://app.publer.io/api/v1';
+const BASE = 'https://app.publer.com/api/v1';
 
 class PublerError extends Error {
   constructor(message, { status, body } = {}) {
@@ -35,7 +35,7 @@ export function createPublerClient({ apiKey, workspaceId, accountIds }) {
   }
 
   const headers = {
-    'Authorization': `Bearer-Api ${apiKey}`,
+    'Authorization': `Bearer-API ${apiKey}`,
     'Publer-Workspace-Id': workspaceId,
     'Content-Type': 'application/json',
   };

--- a/scripts/social/publer-client.mjs
+++ b/scripts/social/publer-client.mjs
@@ -1,0 +1,150 @@
+/**
+ * publer-client.mjs
+ *
+ * Cliente mínimo de la API de Publer v1 para programar posts a redes sociales.
+ *
+ * Auth: Bearer-Api token + Workspace ID en cabeceras.
+ * Docs: https://app.publer.io/api-docs (requiere cuenta business).
+ *
+ * Uso:
+ *   import { createPublerClient } from './publer-client.mjs';
+ *   const client = createPublerClient({ apiKey, workspaceId, accountIds });
+ *   const { jobId } = await client.schedulePost({...});
+ *   const { state, posts } = await client.getJobStatus(jobId);
+ *
+ * Diseño: stateless, sin caché, sin retries. La capa que lo invoca
+ * (scheduler.mjs) decide cómo manejar errores y rate limits.
+ */
+
+const BASE = 'https://app.publer.io/api/v1';
+
+class PublerError extends Error {
+  constructor(message, { status, body } = {}) {
+    super(message);
+    this.name = 'PublerError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export function createPublerClient({ apiKey, workspaceId, accountIds }) {
+  if (!apiKey) throw new Error('publer: apiKey requerido');
+  if (!workspaceId) throw new Error('publer: workspaceId requerido');
+  if (!accountIds || typeof accountIds !== 'object') {
+    throw new Error('publer: accountIds debe ser objeto { instagram: "...", tiktok: "..." }');
+  }
+
+  const headers = {
+    'Authorization': `Bearer-Api ${apiKey}`,
+    'Publer-Workspace-Id': workspaceId,
+    'Content-Type': 'application/json',
+  };
+
+  async function request(path, init = {}) {
+    const res = await fetch(`${BASE}${path}`, {
+      ...init,
+      headers: { ...headers, ...(init.headers ?? {}) },
+    });
+    const text = await res.text();
+    let body;
+    try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+    if (!res.ok) {
+      throw new PublerError(`Publer ${init.method ?? 'GET'} ${path} → ${res.status}`, {
+        status: res.status,
+        body,
+      });
+    }
+    return body;
+  }
+
+  /**
+   * Mapea las plataformas del calendar a los account IDs configurados.
+   * Devuelve un array de account IDs de Publer.
+   */
+  function resolveAccountIds(platforms) {
+    const ids = [];
+    for (const p of platforms) {
+      const id = accountIds[p];
+      if (!id) throw new Error(`publer: account ID no configurado para "${p}"`);
+      ids.push(id);
+    }
+    return ids;
+  }
+
+  /**
+   * Programa un post en Publer.
+   *
+   * Publer trabaja con "jobs" — agruparlo así permite multiplataforma en
+   * una sola llamada y un job_id que sirve para polling de estado.
+   *
+   * @param {Object} input
+   * @param {string[]} input.platforms - ['instagram', 'tiktok', ...]
+   * @param {string}   input.text - caption + hashtags ya unidos
+   * @param {string}   input.scheduledAt - ISO datetime
+   * @param {Array<{type:'image'|'video', url:string, alt?:string}>} input.media
+   * @returns {Promise<{ jobId: string }>}
+   */
+  async function schedulePost({ platforms, text, scheduledAt, media }) {
+    const accounts = resolveAccountIds(platforms);
+    const payload = {
+      bulk: {
+        state: 'scheduled',
+        accounts,
+        type: media[0]?.type === 'video' ? 'video' : 'photo',
+        scheduled_at: scheduledAt,
+      },
+      posts: [
+        {
+          networks: {},
+          accounts,
+          text,
+          media: media.map((m) => ({
+            type: m.type,
+            url: m.url,
+            ...(m.alt ? { alt_text: m.alt } : {}),
+          })),
+          scheduled_at: scheduledAt,
+        },
+      ],
+    };
+
+    const data = await request('/posts/schedule/publish', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    // Publer responde { job_id } o { jobs: [{ id }] } según versión
+    const jobId = data?.job_id ?? data?.jobs?.[0]?.id ?? data?.id ?? null;
+    if (!jobId) throw new PublerError('Publer schedulePost: no jobId en respuesta', { body: data });
+    return { jobId };
+  }
+
+  /**
+   * Consulta el estado de un job. Útil para verificar que Publer
+   * aceptó el envío (no garantiza publicación final — eso depende de
+   * cada red social y se ve en el dashboard de Publer).
+   */
+  async function getJobStatus(jobId) {
+    const data = await request(`/job_status/${encodeURIComponent(jobId)}`);
+    return {
+      state: data?.status ?? 'unknown',
+      posts: data?.payload ?? [],
+      raw: data,
+    };
+  }
+
+  /**
+   * Lista cuentas conectadas en el workspace. Útil para descubrir
+   * los account IDs la primera vez (correr `pnpm social:accounts`).
+   */
+  async function listAccounts() {
+    return request('/accounts');
+  }
+
+  return {
+    schedulePost,
+    getJobStatus,
+    listAccounts,
+  };
+}
+
+export { PublerError };

--- a/scripts/social/scheduler.mjs
+++ b/scripts/social/scheduler.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * scheduler.mjs
+ *
+ * Lee content/social/calendar.json, encuentra posts approved cuyo
+ * scheduled_at ya llegó (con tolerancia ±15min), los envía a Publer
+ * para programar/publicar, y actualiza el estado en el JSON.
+ *
+ * Pensado para ejecutarse desde GitHub Actions cada 30 minutos.
+ *
+ * ENV requerido:
+ *   PUBLER_API_KEY        — Bearer-Api token (Settings → API en Publer)
+ *   PUBLER_WORKSPACE_ID   — Workspace UUID
+ *   PUBLER_ACCOUNT_INSTAGRAM — Account ID de la cuenta @minigolclub
+ *   PUBLER_ACCOUNT_TIKTOK    — opcional, para TikTok
+ *   PUBLER_ACCOUNT_PINTEREST — opcional
+ *   ASSETS_BASE_URL       — URL pública desde donde Publer descarga los assets
+ *                           (ej. raw.githubusercontent.com/.../main o CDN propio).
+ *                           Por defecto: raw GitHub del repo actual.
+ *   GITHUB_REPOSITORY     — auto-inyectado en GH Actions ('owner/repo')
+ *   GITHUB_REF_NAME       — auto-inyectado, default 'main'
+ *
+ * Flags:
+ *   --dry-run    — no llama Publer ni modifica calendar.json. Solo loggea.
+ *   --window=N   — minutos hacia atrás considerados "ahora ya". Default 30.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createPublerClient, PublerError } from './publer-client.mjs';
+
+const CAL_PATH = resolve(process.cwd(), 'content/social/calendar.json');
+
+const args = new Set(process.argv.slice(2));
+const DRY_RUN = args.has('--dry-run');
+const windowArg = [...args].find((a) => a.startsWith('--window='));
+const WINDOW_MIN = windowArg ? Number(windowArg.split('=')[1]) : 30;
+
+function log(msg) { console.log(`[scheduler] ${msg}`); }
+function err(msg) { console.error(`[scheduler] ❌ ${msg}`); }
+
+function readCalendar() {
+  const raw = readFileSync(CAL_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeCalendar(cal) {
+  cal.generated_at = new Date().toISOString();
+  // 2 espacios + newline final → diffs limpios
+  writeFileSync(CAL_PATH, JSON.stringify(cal, null, 2) + '\n', 'utf8');
+}
+
+function platformsKey(post) {
+  return [...post.platforms].sort().join('+');
+}
+
+/**
+ * Construye URL pública de un asset relativo del repo.
+ * Publer necesita URLs HTTPS accesibles desde fuera para descargar
+ * imágenes/vídeos. La estrategia más simple sin CDN propio: raw.githubusercontent.
+ */
+function buildAssetUrl(relativePath, { repo, branch, baseOverride }) {
+  if (baseOverride) {
+    const clean = relativePath.replace(/^\/+/, '');
+    return `${baseOverride.replace(/\/$/, '')}/${clean}`;
+  }
+  if (!repo) throw new Error('GITHUB_REPOSITORY o ASSETS_BASE_URL requerido');
+  const clean = relativePath.replace(/^\/+/, '');
+  return `https://raw.githubusercontent.com/${repo}/${branch}/${clean}`;
+}
+
+function buildText(post) {
+  const tags = (post.hashtags ?? []).map((h) => `#${h}`).join(' ');
+  const parts = [post.caption];
+  if (post.target_url) parts.push(`\n${post.target_url}`);
+  if (tags) parts.push(`\n${tags}`);
+  return parts.filter(Boolean).join('\n');
+}
+
+async function main() {
+  log(`window=${WINDOW_MIN}min · dryRun=${DRY_RUN}`);
+
+  const cal = readCalendar();
+  const now = Date.now();
+  const cutoff = now - WINDOW_MIN * 60 * 1000;
+
+  const due = cal.posts.filter(
+    (p) =>
+      p.status === 'approved' &&
+      Date.parse(p.scheduled_at) <= now &&
+      Date.parse(p.scheduled_at) >= cutoff,
+  );
+
+  // Posts aprobados cuyo scheduled_at ya pasó hace MUCHO — no los publicamos
+  // (puede que el operador los olvidó). Solo los marcamos failed con motivo.
+  const stale = cal.posts.filter(
+    (p) => p.status === 'approved' && Date.parse(p.scheduled_at) < cutoff,
+  );
+
+  log(`due=${due.length} stale=${stale.length} totalApproved=${due.length + stale.length}`);
+
+  if (due.length === 0 && stale.length === 0) {
+    log('Nada que hacer.');
+    return;
+  }
+
+  // Marca stale como failed para que el editor decida (re-aprobar nuevo schedule)
+  if (stale.length > 0) {
+    for (const p of stale) {
+      err(`stale post ${p.id} (scheduled ${p.scheduled_at}) — marcando failed`);
+      p.status = 'failed';
+      p.error = `Skipped: scheduled_at más de ${WINDOW_MIN}min en el pasado al evaluar`;
+    }
+  }
+
+  if (due.length === 0) {
+    if (!DRY_RUN) writeCalendar(cal);
+    return;
+  }
+
+  // Init Publer
+  const apiKey = process.env.PUBLER_API_KEY;
+  const workspaceId = process.env.PUBLER_WORKSPACE_ID;
+  const accountIds = {
+    instagram: process.env.PUBLER_ACCOUNT_INSTAGRAM,
+    tiktok: process.env.PUBLER_ACCOUNT_TIKTOK,
+    pinterest: process.env.PUBLER_ACCOUNT_PINTEREST,
+    facebook: process.env.PUBLER_ACCOUNT_FACEBOOK,
+    x: process.env.PUBLER_ACCOUNT_X,
+    linkedin: process.env.PUBLER_ACCOUNT_LINKEDIN,
+    youtube: process.env.PUBLER_ACCOUNT_YOUTUBE,
+  };
+
+  const repo = process.env.GITHUB_REPOSITORY;
+  const branch = process.env.GITHUB_REF_NAME ?? 'main';
+  const baseOverride = process.env.ASSETS_BASE_URL;
+
+  let client = null;
+  if (!DRY_RUN) {
+    if (!apiKey || !workspaceId) {
+      err('PUBLER_API_KEY o PUBLER_WORKSPACE_ID no configurados');
+      process.exit(1);
+    }
+    client = createPublerClient({ apiKey, workspaceId, accountIds });
+  }
+
+  let okCount = 0;
+  let failCount = 0;
+
+  for (const post of due) {
+    try {
+      const text = buildText(post);
+      const media = post.media.map((m) => ({
+        type: m.type,
+        url: buildAssetUrl(m.path, { repo, branch, baseOverride }),
+        alt: m.alt,
+      }));
+
+      log(`→ ${post.id} (${platformsKey(post)}) ${DRY_RUN ? '[DRY]' : ''}`);
+      log(`  text: ${text.slice(0, 80)}${text.length > 80 ? '...' : ''}`);
+      log(`  media: ${media.map((m) => `${m.type}:${m.url}`).join(', ')}`);
+
+      if (!DRY_RUN) {
+        const { jobId } = await client.schedulePost({
+          platforms: post.platforms,
+          text,
+          scheduledAt: post.scheduled_at,
+          media,
+        });
+        post.status = 'published';
+        post.published_at = new Date().toISOString();
+        post.publer_post_id = jobId;
+        post.error = null;
+        log(`  ✅ jobId=${jobId}`);
+      }
+      okCount++;
+    } catch (e) {
+      failCount++;
+      post.status = 'failed';
+      post.error = e instanceof PublerError
+        ? `${e.message} body=${JSON.stringify(e.body).slice(0, 200)}`
+        : e.message;
+      err(`  fallo en ${post.id}: ${post.error}`);
+    }
+  }
+
+  log(`Resumen: ok=${okCount} fail=${failCount}`);
+
+  if (!DRY_RUN) writeCalendar(cal);
+
+  if (failCount > 0 && okCount === 0) process.exit(1); // todo falló → fail CI
+}
+
+main().catch((e) => {
+  err(`fatal: ${e.stack ?? e.message}`);
+  process.exit(1);
+});

--- a/scripts/social/scheduler.mjs
+++ b/scripts/social/scheduler.mjs
@@ -9,7 +9,7 @@
  * Pensado para ejecutarse desde GitHub Actions cada 30 minutos.
  *
  * ENV requerido:
- *   PUBLER_API_KEY        — Bearer-Api token (Settings → API en Publer)
+ *   PUBLER_API_KEY        — Bearer-API token (Settings → Access & Login → Manage API Keys en Publer)
  *   PUBLER_WORKSPACE_ID   — Workspace UUID
  *   PUBLER_ACCOUNT_INSTAGRAM — Account ID de la cuenta @minigolclub
  *   PUBLER_ACCOUNT_TIKTOK    — opcional, para TikTok

--- a/scripts/social/validate-calendar.mjs
+++ b/scripts/social/validate-calendar.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * validate-calendar.mjs
+ *
+ * Valida content/social/calendar.json contra su schema. Uso:
+ *   node scripts/social/validate-calendar.mjs
+ *
+ * Falla con exit 1 si hay errores. Pensado para correr en CI antes
+ * del scheduler real, y localmente vía `pnpm social:validate`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CAL_PATH = resolve(process.cwd(), 'content/social/calendar.json');
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+function ok(msg) {
+  console.log(`✅ ${msg}`);
+}
+
+let raw;
+try {
+  raw = readFileSync(CAL_PATH, 'utf8');
+} catch {
+  fail(`No puedo leer ${CAL_PATH}`);
+}
+
+let cal;
+try {
+  cal = JSON.parse(raw);
+} catch (e) {
+  fail(`calendar.json no es JSON válido: ${e.message}`);
+}
+
+// --- Estructura mínima ---
+if (cal.version !== 1) fail(`version debe ser 1, es ${cal.version}`);
+if (!Array.isArray(cal.posts)) fail('posts debe ser array');
+
+const VALID_PLATFORMS = new Set([
+  'instagram', 'facebook', 'tiktok', 'x', 'linkedin', 'pinterest', 'youtube',
+]);
+const VALID_FORMATS = new Set([
+  'single_image', 'carousel', 'reel', 'story', 'video', 'text',
+]);
+const VALID_STATUSES = new Set([
+  'draft', 'approved', 'published', 'failed', 'archived',
+]);
+const VALID_LOCALES = new Set(['es', 'ca']);
+const VALID_MEDIA = new Set(['image', 'video']);
+
+const ID_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z]{2,5}-[a-z0-9-]+$/;
+
+const ids = new Set();
+let errors = 0;
+
+for (const [i, p] of cal.posts.entries()) {
+  const ctx = `posts[${i}] (id=${p?.id ?? '?'})`;
+  const pushErr = (m) => { errors++; console.error(`  ❌ ${ctx}: ${m}`); };
+
+  if (!p.id || !ID_RE.test(p.id)) pushErr(`id inválido (debe ser YYYY-MM-DD-platform-slug)`);
+  if (ids.has(p.id)) pushErr(`id duplicado`);
+  ids.add(p.id);
+
+  if (!Array.isArray(p.platforms) || p.platforms.length === 0) pushErr(`platforms vacío`);
+  for (const pl of p.platforms ?? []) if (!VALID_PLATFORMS.has(pl)) pushErr(`platform inválida: ${pl}`);
+
+  if (!VALID_FORMATS.has(p.format)) pushErr(`format inválido: ${p.format}`);
+  if (!VALID_STATUSES.has(p.status)) pushErr(`status inválido: ${p.status}`);
+  if (!VALID_LOCALES.has(p.locale)) pushErr(`locale inválido: ${p.locale}`);
+
+  if (!p.scheduled_at) pushErr(`scheduled_at vacío`);
+  else if (Number.isNaN(Date.parse(p.scheduled_at))) pushErr(`scheduled_at no parseable: ${p.scheduled_at}`);
+
+  if (!p.caption || typeof p.caption !== 'string') pushErr(`caption vacío`);
+  else if (p.caption.length > 2200) pushErr(`caption excede 2200 chars (${p.caption.length})`);
+
+  if (Array.isArray(p.hashtags) && p.hashtags.length > 30) pushErr(`hashtags excede 30 (${p.hashtags.length})`);
+
+  if (!Array.isArray(p.media) || p.media.length === 0) pushErr(`media vacío`);
+  else if (p.media.length > 10) pushErr(`media excede 10`);
+  else {
+    for (const [j, m] of p.media.entries()) {
+      if (!VALID_MEDIA.has(m.type)) pushErr(`media[${j}].type inválido: ${m.type}`);
+      if (!m.path || typeof m.path !== 'string') pushErr(`media[${j}].path vacío`);
+    }
+  }
+
+  if (p.target_url && typeof p.target_url === 'string') {
+    try { new URL(p.target_url); } catch { pushErr(`target_url no es URL válida: ${p.target_url}`); }
+  }
+}
+
+if (errors > 0) fail(`${errors} error(es) en calendar.json`);
+
+ok(`calendar.json válido — ${cal.posts.length} post(s).`);
+
+// Resumen por status
+const byStatus = {};
+for (const p of cal.posts) {
+  byStatus[p.status] = (byStatus[p.status] ?? 0) + 1;
+}
+console.log(`   Resumen: ${Object.entries(byStatus).map(([k, v]) => `${k}=${v}`).join(' · ')}`);
+
+// Próximos approved
+const nowMs = Date.now();
+const upcoming = cal.posts
+  .filter((p) => p.status === 'approved' && Date.parse(p.scheduled_at) > nowMs)
+  .sort((a, b) => Date.parse(a.scheduled_at) - Date.parse(b.scheduled_at))
+  .slice(0, 3);
+
+if (upcoming.length > 0) {
+  console.log(`\n   Próximos approved:`);
+  for (const p of upcoming) console.log(`   • ${p.scheduled_at} → ${p.id}`);
+}


### PR DESCRIPTION
## Summary
Sistema de publicación programada cross-platform a redes sociales. **Saltamos directo a Fase 2** del roadmap (PR #49) porque ya tienes licencia Publer.

## Arquitectura

\`\`\`
content/social/calendar.json   ← editor escribe, status: draft → approved
        │
        ▼ cada 30 min (cron GitHub Actions)
.github/workflows/social-scheduler.yml
        │
        ▼
scripts/social/scheduler.mjs → publer-client.mjs → Publer API
        │
        ▼
git commit "scheduler ... — actualizar status"
        (status: approved → published / failed)
\`\`\`

## Ficheros creados

| Fichero | Función |
|---------|---------|
| \`content/social/calendar.json\` | Source of truth. 3 posts semilla CA |
| \`content/social/calendar.schema.json\` | Schema JSON (autocompletado VSCode + validación) |
| \`scripts/social/validate-calendar.mjs\` | Validador (CI + local) |
| \`scripts/social/publer-client.mjs\` | Cliente Publer mínimo |
| \`scripts/social/scheduler.mjs\` | Lee calendar, publica, actualiza status |
| \`scripts/social/list-accounts.mjs\` | Helper para descubrir Account IDs |
| \`.github/workflows/social-scheduler.yml\` | Cron \`*/30 * * * *\` + dispatch manual con dry_run |
| \`.github/workflows/ci.yml\` | Job \`social-calendar\` añadido (valida en cada PR) |
| \`docs/SchedulerPubler.md\` | Guía completa setup + uso |

## Decisiones vs. enfoque LYJ
- ✅ **JSON en Git como source of truth** (no \`localStorage\` ni DB) — auditable, revisable por PR
- ✅ **Aprobación humana = merge a main** (no toggle local) — no se publica nada sin mergear
- ✅ **Publer como capa de publicación** — evita meses de aprobación oficial Meta/TikTok
- ✅ **Assets via raw GitHub** mientras no haya CDN propio (override con \`ASSETS_BASE_URL\`)
- ✅ **Stale posts** (approved con scheduled_at >30min en el pasado al evaluar) se marcan \`failed\` para revisión — evita publicar tarde y descontextualizado

## Setup pendiente (acción del usuario)

1. **Publer:** crear cuenta business → conectar @minigolclub Instagram → generar API Key
2. **Account IDs:** \`PUBLER_API_KEY=xxx PUBLER_WORKSPACE_ID=yyy pnpm social:accounts\` para descubrirlos
3. **GitHub Secrets** (\`Settings → Secrets and variables → Actions\`):
   - \`PUBLER_API_KEY\`
   - \`PUBLER_WORKSPACE_ID\`
   - \`PUBLER_ACCOUNT_INSTAGRAM\`
   - (otros opcionales)
4. **Assets:** subir las imágenes/vídeos de los 3 posts semilla a \`public/social/<slug>/\`
5. **Aprobar posts:** cambiar \`"status": "draft"\` → \`"status": "approved"\` y mergear a main

Después de eso → en el siguiente cron (max 30 min) Publer recibe los posts y los programa.

## Test plan
- [x] \`pnpm social:validate\` → calendar válido
- [x] \`pnpm social:dry\` (con post hackeado a approved) → procesa correctamente, construye URLs raw GitHub bien
- [ ] Tras setup secrets + assets: \`workflow_dispatch\` con \`dry_run=true\` desde GitHub Actions
- [ ] Aprobar 1 post real y esperar al cron

## Próximas iteraciones (no en este PR)
- Generador de imágenes sociales con Satori desde frontmatter de artículo
- Worker Cron de detección de tendencias futbol infantil (estilo LYJ \`bts-trending\`)
- Vista web interna del calendar como timeline visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)