### PR TITLE
content(ejercicios): PizarraCallout en 6 artículos de ejercicios

### DIFF
--- a/src/content/articulos/ejercicios/calentamiento-futbol-ninos-10-minutos.mdx
+++ b/src/content/articulos/ejercicios/calentamiento-futbol-ninos-10-minutos.mdx
@@ -19,9 +19,18 @@ tieneAfiliados: false
 featured: false
 ---
 
+import PizarraCallout from '@/components/ui/PizarraCallout.astro';
+
 Un **calentamiento de fútbol para niños de 10 minutos** es la diferencia entre un entrenamiento seguro y divertido, y una clase donde los pequeños se lesionan o pierden concentración a los cinco minutos. He visto demasiadas veces padres e instructores saltar esta fase pensando que "los niños tienen energía ilimitada". Falso. El cuerpo de un niño entre 6 y 12 años necesita prepararse exactamente igual que el de un adulto, solo que con una estructura lúdica que mantenga su atención.
 
 En este artículo te doy la rutina completa, probada en cientos de sesiones, adaptable a cualquier espacio y sin material complicado.
+
+<PizarraCallout
+  preset="calentamiento"
+  title="Visualiza el circuito de calentamiento"
+  description="Abre la pizarra con el preset de calentamiento — coloca conos, marca recorridos y enseña la rutina al niño con un esquema claro."
+  cta="Abrir circuito en la pizarra"
+/>
 
 ## Por qué el calentamiento no se puede saltar (nunca)
 

--- a/src/content/articulos/ejercicios/conduccion-balon-futbol-ninos.mdx
+++ b/src/content/articulos/ejercicios/conduccion-balon-futbol-ninos.mdx
@@ -19,7 +19,16 @@ tieneAfiliados: false
 featured: false
 ---
 
+import PizarraCallout from '@/components/ui/PizarraCallout.astro';
+
 Enseñar **conducción de balón fútbol niños** es la primera habilidad técnica que marca la diferencia entre un chaval que disfruta jugando y uno que se frustra porque el balón "no le obedece". No hace falta un campo ni equipamiento especial: 10 minutos al día en cualquier superficie lisa son suficientes para notar progreso en pocas semanas.
+
+<PizarraCallout
+  preset="conduccion-zigzag"
+  title="Visualiza el slalom de conducción"
+  description="Abre la pizarra con el preset de conducción en zigzag — mueve los conos, anima al niño jugador y prueba variaciones antes de bajar al campo."
+  cta="Abrir slalom en la pizarra"
+/>
 
 ## Por qué la conducción es la base del fútbol infantil
 

--- a/src/content/articulos/ejercicios/dinamicas-grupo-entrenamientos-futbol-infantil.mdx
+++ b/src/content/articulos/ejercicios/dinamicas-grupo-entrenamientos-futbol-infantil.mdx
@@ -17,7 +17,16 @@ tieneAfiliados: false
 featured: false
 ---
 
+import PizarraCallout from '@/components/ui/PizarraCallout.astro';
+
 Los niños necesitan sentirse parte de algo. Una colección de talentos individuales nunca será un equipo sin lo que llamamos **dinámicas de grupo**: esos ejercicios que transforman a 11 cuerpos en un organismo que respira junto, que se comunica sin palabras, que se levanta cuando uno cae. Este artículo te da 8 **dinámicas de grupo para entrenamientos de fútbol infantil**, probadas en campos de toda España, para entrenadores amateurs, padres-entrenadores y monitores de escuela que quieren construir equipos de verdad, no solo alineaciones.
+
+<PizarraCallout
+  preset="rondo-4v1"
+  title="Diseña tus rondos en la pizarra"
+  description="El rondo 4 contra 1 es la base de muchas dinámicas de grupo — ábrelo en la pizarra, mueve a los jugadores y enseña posiciones antes de la sesión."
+  cta="Abrir rondo 4v1"
+/>
 
 ## Por qué las dinámicas de grupo importan en fútbol infantil
 

--- a/src/content/articulos/ejercicios/ejercicios-coordinacion-futbol-ninos.mdx
+++ b/src/content/articulos/ejercicios/ejercicios-coordinacion-futbol-ninos.mdx
@@ -17,9 +17,18 @@ tieneAfiliados: false
 featured: false
 ---
 
+import PizarraCallout from '@/components/ui/PizarraCallout.astro';
+
 A partir de los 7 años, el cerebro de tu peque pasa de "controlar el balón" a **coordinar el balón con el resto del cuerpo**. Si hasta ahora le bastaba con tocar la pelota, ahora tiene que tocarla mientras corre, gira, mira al lado o salta.
 
 Estos 6 **ejercicios de coordinación de fútbol para niños** trabajan justo eso. Sirven para 7-9 años (con adaptaciones que verás al final), se hacen en 25 minutos y no necesitas escalera de coordinación ni picas profesionales — con cinta de pintor y conos baratos vale.
+
+<PizarraCallout
+  preset="conduccion-zigzag"
+  title="Diseña los recorridos en la pizarra"
+  description="Coloca conos virtuales, dibuja el recorrido del niño y prueba el zigzag — luego replícalo en el patio sin sorpresas."
+  cta="Abrir circuito en la pizarra"
+/>
 
 ## Antes de empezar
 

--- a/src/content/articulos/ejercicios/ejercicios-futbol-6-anos.mdx
+++ b/src/content/articulos/ejercicios/ejercicios-futbol-6-anos.mdx
@@ -19,7 +19,16 @@ tieneAfiliados: false
 featured: true
 ---
 
+import PizarraCallout from '@/components/ui/PizarraCallout.astro';
+
 A los 6 años, tu hijo está en el momento ideal para descubrir el fútbol de forma divertida y sin presión. No es época de tácticas complejas ni de ser el mejor del equipo: es tiempo de jugar, aprender a controlar el balón y disfrutar. En esta guía te comparto 8 ejercicios progresivos que puedes hacer en tu casa, el parque o el patio del colegio, sin necesidad de cancha profesional ni equipo sofisticado.
+
+<PizarraCallout
+  preset="mini-3v3"
+  title="Diséñate un mini 3 contra 3"
+  description="Para esta edad nada motiva más que un partidito reducido. Abre el preset 3v3, coloca a los niños y enséñales sus posiciones de forma visual."
+  cta="Abrir mini 3v3"
+/>
 
 ## Por qué los 6 años es la edad perfecta para empezar con técnica básica
 

--- a/src/content/articulos/ejercicios/pase-control-balon-ninos.mdx
+++ b/src/content/articulos/ejercicios/pase-control-balon-ninos.mdx
@@ -19,7 +19,16 @@ tieneAfiliados: false
 featured: false
 ---
 
+import PizarraCallout from '@/components/ui/PizarraCallout.astro';
+
 El **pase y control del balón** son los pilares del fútbol colectivo, especialmente en categorías infantiles. A diferencia del regate o el tiro, que dependen del talento individual, estas dos habilidades definen a un jugador que entiende el juego como un todo. Si tu hijo aprende a pasar con precisión y controlar el balón sin nervios, habrá dado un salto gigantesco en su desarrollo futbolístico. Veamos cómo enseñarle las técnicas fundamentales del **pase y control de balón en niños**, con ejercicios prácticos para cualquier parque.
+
+<PizarraCallout
+  preset="pase-y-va"
+  title="Diséñalo en la pizarra antes de bajar al parque"
+  description="Visualiza el pase-y-va paso a paso: coloca a los dos niños, dibuja el pase y la carrera de apoyo. Llévate el plan claro al campo."
+  cta="Abrir pase-y-va"
+/>
 
 ## Por qué el pase y el control son la base del fútbol colectivo
 


### PR DESCRIPTION
## Summary
Sprint 13 #B2 cerrado — inserta el componente \`<PizarraCallout>\` (creado en PR #46) en 6 artículos de ejercicios donde hay un preset de la pizarra que encaja naturalmente con el contenido.

## Emparejamiento artículo ↔ preset

| Artículo | Preset | Por qué encaja |
|----------|--------|----------------|
| \`conduccion-balon-futbol-ninos\` | \`conduccion-zigzag\` | Slalom es ejercicio canónico de conducción |
| \`pase-control-balon-ninos\` | \`pase-y-va\` | Mismo gesto técnico |
| \`calentamiento-futbol-ninos-10-min\` | \`calentamiento\` | Match 1:1 |
| \`dinamicas-grupo-entrenamientos\` | \`rondo-4v1\` | El rondo es la dinámica grupal canónica |
| \`ejercicios-coordinacion-futbol\` | \`conduccion-zigzag\` | Trabaja zigzag de conos |
| \`ejercicios-futbol-6-anos\` | \`mini-3v3\` | A esa edad nada motiva más que un partido reducido |

## Impacto esperado
- **Descubribilidad de la pizarra:** cada visitante de un artículo de ejercicios ve el callout amarillo marker → CTR estimado 5-10% al hub \`/pizarra/\`
- **SEO internal linking:** 6 enlaces nuevos de artículos top → hub Pizarra refuerzan autoridad temática
- **UX:** el callout va tras el primer párrafo, posición de máxima atención sin interrumpir lectura

## Test plan
- [ ] Abrir cada artículo en preview Cloudflare → verificar callout amarillo aparece tras intro
- [ ] Clic en CTA → llega a \`/pizarra/?preset=<id>\`
- [ ] Verificar que la pizarra precarga el preset correcto al llegar
- [ ] Lighthouse no regresiona (sin JS extra)

## Próximos
- Más callouts en el resto de artículos de ejercicios cuando haya nuevos presets en la pizarra
- Generador automático de assets sociales con Satori (PR siguiente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)