### PR TITLE
chore: ignorar admin/.vite y admin/dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ node_modules/
 dist/
 .astro/
 
+# Vite cache (admin React standalone)
+admin/.vite/
+admin/dist/
+
 # Environment
 .env
 .env.local


### PR DESCRIPTION
## Summary
- Añade \`admin/.vite/\` y \`admin/dist/\` al .gitignore para evitar que el cache del Vite del admin React aparezca como untracked en cada \`git status\`

## Test plan
- [x] \`git status\` ya no muestra \`admin/.vite/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)