### PR TITLE
feat(admin): SocialCalendarPage React + InstagramPreview (Sprint 14 · B1)

### DIFF
--- a/admin/src/components/social/InstagramPreview.jsx
+++ b/admin/src/components/social/InstagramPreview.jsx
@@ -1,0 +1,120 @@
+import { socialAssetUrl } from '../../services/socialAPI.js';
+
+const ASPECT_BY_FORMAT = {
+  single_image: '1 / 1',
+  carousel: '1 / 1',
+  reel: '9 / 16',
+  video: '9 / 16',
+  story: '9 / 16',
+  text: '1 / 1',
+};
+
+function fmtTime(iso) {
+  const d = new Date(iso);
+  return d.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' });
+}
+
+function fmtDay(iso) {
+  const d = new Date(iso);
+  return d.toLocaleDateString('es-ES', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+export default function InstagramPreview({ post }) {
+  const firstAsset = post.media?.[0];
+  if (!firstAsset) return null;
+
+  const aspect = ASPECT_BY_FORMAT[post.format] || '1 / 1';
+  const imgUrl = post.assetReady ? socialAssetUrl(firstAsset.path) : null;
+
+  return (
+    <div className="ig-mock">
+      <div className="ig-mock__hdr">
+        <div className="ig-mock__avatar">M</div>
+        <div className="ig-mock__user">
+          <div className="ig-mock__name">minigolclub</div>
+          <div className="ig-mock__loc">MiniGol Club · Programado</div>
+        </div>
+        <svg width={20} height={20} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" style={{ color: '#262626' }}>
+          <circle cx="12" cy="12" r="1" />
+          <circle cx="19" cy="12" r="1" />
+          <circle cx="5" cy="12" r="1" />
+        </svg>
+      </div>
+
+      {imgUrl ? (
+        <div className="ig-mock__media" style={{ aspectRatio: aspect }}>
+          <img src={imgUrl} alt={firstAsset.alt || ''} loading="lazy" />
+          {post.format === 'carousel' && (
+            <span className="ig-mock__badge">
+              <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                <polygon points="12 2 2 7 12 12 22 7 12 2" />
+                <polyline points="2 17 12 22 22 17" />
+                <polyline points="2 12 12 17 22 12" />
+              </svg>
+              1/1
+            </span>
+          )}
+          {(post.format === 'reel' || post.format === 'video') && (
+            <span className="ig-mock__badge">
+              <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                <polygon points="5 3 19 12 5 21 5 3" />
+              </svg>
+              Reel
+            </span>
+          )}
+        </div>
+      ) : (
+        <div className="ig-mock__media ig-mock__media--missing" style={{ aspectRatio: aspect }}>
+          <svg width={40} height={40} viewBox="0 0 24 24" fill="none" stroke="#999" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">
+            <line x1="2" y1="2" x2="22" y2="22" />
+            <path d="M10.41 10.41a2 2 0 1 1-2.83-2.83" />
+            <line x1="13.5" y1="13.5" x2="6" y2="21" />
+            <line x1="18" y1="12" x2="21" y2="9" />
+            <path d="M3.59 3.59A1.99 1.99 0 0 0 3 5v14a2 2 0 0 0 2 2h14c.55 0 1.05-.22 1.41-.59" />
+            <path d="M21 15V5a2 2 0 0 0-2-2H9" />
+          </svg>
+          <span style={{ marginTop: 8, fontSize: 12, color: '#666' }}>
+            Falta el asset: {firstAsset.path}
+          </span>
+        </div>
+      )}
+
+      <div className="ig-mock__actions">
+        <svg width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+        </svg>
+        <svg width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        <svg width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+          <line x1="22" y1="2" x2="11" y2="13" />
+          <polygon points="22 2 15 22 11 13 2 9 22 2" />
+        </svg>
+        <span className="ig-mock__spacer" />
+        <svg width={24} height={24} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+        </svg>
+      </div>
+
+      <div className="ig-mock__body">
+        <p className="ig-mock__caption">
+          <strong>minigolclub</strong>{' '}
+          <span style={{ whiteSpace: 'pre-line' }}>{post.caption}</span>
+        </p>
+        {post.hashtags && post.hashtags.length > 0 && (
+          <p className="ig-mock__tags">
+            {post.hashtags.map((h) => '#' + h).join(' ')}
+          </p>
+        )}
+        <p className="ig-mock__meta">
+          Programado para {fmtDay(post.scheduled_at)} · {fmtTime(post.scheduled_at)}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/admin/src/hooks/useSocialCalendar.js
+++ b/admin/src/hooks/useSocialCalendar.js
@@ -1,0 +1,22 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchSocialCalendar } from '../services/socialAPI.js';
+
+export function useSocialCalendar() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refetch = useCallback(() => {
+    setLoading(true);
+    return fetchSocialCalendar()
+      .then((d) => { setData(d); setError(null); })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { data, loading, error, refetch };
+}

--- a/admin/src/index.css
+++ b/admin/src/index.css
@@ -347,3 +347,140 @@ h3 {
   margin-left: 8px;
   vertical-align: middle;
 }
+
+/* Instagram mock preview */
+
+.ig-mock {
+  max-width: 470px;
+  margin-inline: auto;
+  background: #ffffff;
+  color: #262626;
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.4;
+}
+
+.ig-mock__hdr {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+}
+
+.ig-mock__avatar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f58529, #dd2a7b 50%, #515bd4);
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 800;
+  font-size: 14px;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1.5px #dd2a7b;
+}
+
+.ig-mock__user {
+  flex: 1;
+  min-width: 0;
+}
+
+.ig-mock__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #262626;
+}
+
+.ig-mock__loc {
+  font-size: 11px;
+  color: #737373;
+}
+
+.ig-mock__media {
+  position: relative;
+  width: 100%;
+  background: #fafafa;
+  border-block: 1px solid #efefef;
+}
+
+.ig-mock__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.ig-mock__media--missing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: repeating-linear-gradient(
+    45deg,
+    #f5f5f5,
+    #f5f5f5 10px,
+    #fafafa 10px,
+    #fafafa 20px
+  );
+}
+
+.ig-mock__badge {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 11px;
+  border-radius: 6px;
+  backdrop-filter: blur(2px);
+}
+
+.ig-mock__actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px 4px;
+  color: #262626;
+}
+
+.ig-mock__spacer {
+  flex: 1;
+}
+
+.ig-mock__body {
+  padding: 4px 14px 14px;
+}
+
+.ig-mock__caption {
+  margin: 0;
+  font-size: 14px;
+  color: #262626;
+}
+
+.ig-mock__caption strong {
+  font-weight: 600;
+  margin-right: 4px;
+}
+
+.ig-mock__tags {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: #00376b;
+  word-break: break-word;
+}
+
+.ig-mock__meta {
+  margin: 12px 0 0;
+  font-size: 11px;
+  color: #737373;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/admin/src/pages/SocialCalendarPage.jsx
+++ b/admin/src/pages/SocialCalendarPage.jsx
@@ -1,20 +1,383 @@
-export default function SocialCalendarPage() {
+import { useState } from 'react';
+import { useSocialCalendar } from '../hooks/useSocialCalendar.js';
+import InstagramPreview from '../components/social/InstagramPreview.jsx';
+
+const STATUS_STYLE = {
+  draft:     { bg: '#e5e7eb', fg: '#374151', label: 'Borrador' },
+  approved:  { bg: '#FACC15', fg: '#1a1f2c', label: 'Aprobado' },
+  published: { bg: '#16A34A', fg: '#ffffff', label: 'Publicado' },
+  failed:    { bg: '#DC2626', fg: '#ffffff', label: 'Falló' },
+  archived:  { bg: '#9ca3af', fg: '#1a1f2c', label: 'Archivado' },
+};
+
+const PLATFORM_LABEL = {
+  instagram: 'Instagram',
+  facebook: 'Facebook',
+  tiktok: 'TikTok',
+  x: 'X',
+  linkedin: 'LinkedIn',
+  pinterest: 'Pinterest',
+  youtube: 'YouTube',
+};
+
+const FORMAT_LABEL = {
+  single_image: 'Imagen',
+  carousel: 'Carrusel',
+  reel: 'Reel',
+  story: 'Story',
+  video: 'Vídeo',
+  text: 'Texto',
+};
+
+function dayKey(iso) {
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+function fmtDay(key) {
+  const d = new Date(`${key}T12:00:00`);
+  return d.toLocaleDateString('es-ES', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function fmtTime(iso) {
+  return new Date(iso).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' });
+}
+
+function previewCaption(caption, max = 140) {
+  if (!caption) return '';
+  if (caption.length <= max) return caption;
+  return caption.slice(0, max).trim() + '…';
+}
+
+function PostCard({ post }) {
+  const [showPreview, setShowPreview] = useState(false);
+  const status = STATUS_STYLE[post.status] || STATUS_STYLE.draft;
+
   return (
-    <div style={{ maxWidth: 720, margin: '40px auto', textAlign: 'center' }}>
-      <div
-        className="card-paper"
-        style={{ padding: '40px 32px', borderStyle: 'dashed' }}
-      >
-        <div className="stamp">Próximamente</div>
-        <h1 style={{ marginTop: 12, marginBottom: 8, fontSize: 24 }}>
+    <article
+      className="card-paper"
+      style={{
+        padding: 20,
+        borderLeft: `6px solid ${status.bg}`,
+      }}
+    >
+      <header style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
+          <span
+            className="mono"
+            style={{
+              display: 'inline-block',
+              borderRadius: 9999,
+              padding: '4px 12px',
+              fontSize: 11,
+              fontWeight: 700,
+              background: status.bg,
+              color: status.fg,
+              letterSpacing: '0.05em',
+            }}
+          >
+            {status.label}
+          </span>
+          {post.platforms?.map((pl) => (
+            <span
+              key={pl}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                borderRadius: 6,
+                padding: '4px 8px',
+                fontSize: 11,
+                fontWeight: 500,
+                background: 'var(--color-surface-alt)',
+                color: 'var(--color-foreground)',
+              }}
+            >
+              {PLATFORM_LABEL[pl] || pl}
+            </span>
+          ))}
+          <span
+            className="mono"
+            style={{
+              display: 'inline-block',
+              borderRadius: 6,
+              padding: '4px 8px',
+              fontSize: 11,
+              background: 'var(--color-surface-alt)',
+              color: 'var(--color-foreground-muted)',
+            }}
+          >
+            {FORMAT_LABEL[post.format] || post.format}
+          </span>
+          <span
+            className="mono"
+            style={{
+              display: 'inline-block',
+              borderRadius: 6,
+              padding: '4px 8px',
+              fontSize: 11,
+              textTransform: 'uppercase',
+              background: 'var(--color-surface-alt)',
+              color: 'var(--color-foreground-muted)',
+              letterSpacing: '0.06em',
+            }}
+          >
+            {post.locale}
+          </span>
+          {post.isOverdue && (
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                borderRadius: 6,
+                padding: '4px 8px',
+                fontSize: 11,
+                fontWeight: 700,
+                background: '#FEF3C7',
+                color: '#92400E',
+              }}
+            >
+              ⚠ vencido
+            </span>
+          )}
+        </div>
+        <time
+          className="mono"
+          style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-foreground-muted)' }}
+          dateTime={post.scheduled_at}
+        >
+          {fmtTime(post.scheduled_at)}
+        </time>
+      </header>
+
+      <p style={{ marginTop: 12, fontSize: 13, lineHeight: 1.5, color: 'var(--color-foreground)', whiteSpace: 'pre-line' }}>
+        {previewCaption(post.caption)}
+      </p>
+
+      <div style={{ marginTop: 12, display: 'flex', flexWrap: 'wrap', gap: '8px 16px', fontSize: 11 }}>
+        {post.target_url && (
+          <a
+            href={post.target_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--color-primary)', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+          >
+            ↗ {post.article_slug || 'destino'}
+          </a>
+        )}
+        {post.media?.[0] && (
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              color: post.assetReady ? 'var(--color-secondary)' : 'var(--color-energy)',
+            }}
+          >
+            {post.assetReady ? '✓' : '✗'} {post.media[0].path}
+          </span>
+        )}
+        {post.hashtags && post.hashtags.length > 0 && (
+          <span className="mono" style={{ color: 'var(--color-foreground-muted)' }}>
+            {post.hashtags.length} hashtags
+          </span>
+        )}
+        <span className="mono" style={{ color: 'var(--color-foreground-subtle)' }}>
+          id: {post.id}
+        </span>
+      </div>
+
+      {post.error && (
+        <div style={{ marginTop: 12, padding: 12, borderRadius: 6, fontSize: 12, background: '#FEE2E2', color: '#991B1B' }}>
+          <strong>Error:</strong> {post.error}
+        </div>
+      )}
+
+      {post.notes && (
+        <p className="hand" style={{ marginTop: 12, fontSize: 16 }}>
+          ✏ {post.notes}
+        </p>
+      )}
+
+      {post.publer_post_id && (
+        <p className="mono" style={{ marginTop: 12, fontSize: 11, color: 'var(--color-foreground-subtle)' }}>
+          Publer job: {post.publer_post_id}
+        </p>
+      )}
+
+      {post.platforms?.includes('instagram') && post.media?.[0] && (
+        <div style={{ marginTop: 16 }}>
+          <button
+            type="button"
+            onClick={() => setShowPreview((v) => !v)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              fontSize: 13,
+              fontWeight: 600,
+              color: 'var(--color-primary)',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+            }}
+          >
+            👁 {showPreview ? 'Ocultar' : 'Vista previa'} Instagram
+          </button>
+          {showPreview && (
+            <div style={{ marginTop: 16 }}>
+              <InstagramPreview post={post} />
+            </div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default function SocialCalendarPage() {
+  const { data, loading, error, refetch } = useSocialCalendar();
+
+  if (loading) {
+    return (
+      <div style={{ padding: 40, textAlign: 'center', color: 'var(--color-foreground-muted)' }}>
+        Cargando calendar…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="card-paper" style={{ padding: 24, background: '#FEE2E2', borderColor: '#DC2626' }}>
+        <strong style={{ color: '#991B1B' }}>Error:</strong>{' '}
+        <span style={{ color: '#991B1B' }}>{error}</span>
+      </div>
+    );
+  }
+
+  const { posts = [], counts = {}, upcomingApproved = 0, overdueApproved = 0 } = data || {};
+
+  const sorted = [...posts].sort(
+    (a, b) => Date.parse(a.scheduled_at) - Date.parse(b.scheduled_at),
+  );
+  const grouped = new Map();
+  for (const p of sorted) {
+    const key = dayKey(p.scheduled_at);
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(p);
+  }
+
+  return (
+    <div>
+      <header style={{ marginBottom: 32 }}>
+        <p className="mono" style={{ fontSize: 11, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.12em', color: 'var(--color-foreground-subtle)' }}>
+          Admin · solo visualización
+        </p>
+        <h1 style={{ margin: '8px 0 0', fontSize: 'clamp(2rem, 4vw, 2.75rem)', lineHeight: 1, letterSpacing: '-0.02em' }}>
           Social Calendar
         </h1>
-        <p style={{ color: 'var(--color-foreground-muted)', fontSize: 14 }}>
-          La portación desde Astro llega en el siguiente PR (Wave 2).
-          Mientras tanto puedes editar <code>content/social/calendar.json</code>{' '}
-          en Git y consultarlo en la página Astro <code>/admin/social/</code>.
+        <p style={{ marginTop: 12, fontSize: 13, color: 'var(--color-foreground-muted)' }}>
+          Lectura de <code style={{ fontFamily: 'var(--font-mono)', padding: '2px 6px', background: 'var(--color-surface-alt)', borderRadius: 4 }}>content/social/calendar.json</code>.{' '}
+          Para editar, modifica el JSON en Git y abre PR.
+          <button
+            type="button"
+            onClick={refetch}
+            className="mono"
+            style={{
+              marginLeft: 12,
+              fontSize: 11,
+              padding: '4px 10px',
+              borderRadius: 6,
+              background: 'var(--color-surface-alt)',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--color-foreground)',
+            }}
+          >
+            ↻ Recargar
+          </button>
         </p>
-      </div>
+      </header>
+
+      <section style={{ marginBottom: 32, display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))' }}>
+        {Object.entries(STATUS_STYLE).map(([s, style]) => (
+          <div key={s} className="card-paper" style={{ padding: 16 }}>
+            <div className="mono" style={{ fontSize: 11, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.08em', color: style.bg }}>
+              {style.label}
+            </div>
+            <div style={{ marginTop: 4, fontSize: 30, fontFamily: 'var(--font-display)', fontWeight: 700, lineHeight: 1 }}>
+              {counts[s] ?? 0}
+            </div>
+          </div>
+        ))}
+      </section>
+
+      {(overdueApproved > 0 || upcomingApproved > 0) && (
+        <section style={{ marginBottom: 24, display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))' }}>
+          {overdueApproved > 0 && (
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, padding: 16, borderRadius: 8, background: '#FEF3C7', border: '1px solid #D97706' }}>
+              <span style={{ fontSize: 20 }}>⚠</span>
+              <div>
+                <p style={{ fontSize: 13, fontWeight: 700, color: '#92400E' }}>
+                  {overdueApproved} post(s) approved con fecha pasada
+                </p>
+                <p style={{ marginTop: 4, fontSize: 11, color: '#92400E' }}>
+                  El próximo cron del scheduler los marcará como <code>failed</code> si quedan fuera de la ventana.
+                </p>
+              </div>
+            </div>
+          )}
+          {upcomingApproved > 0 && (
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, padding: 16, borderRadius: 8, background: '#DCFCE7', border: '1px solid #16A34A' }}>
+              <span style={{ fontSize: 20 }}>✓</span>
+              <div>
+                <p style={{ fontSize: 13, fontWeight: 700, color: '#166534' }}>
+                  {upcomingApproved} post(s) approved en la cola
+                </p>
+                <p style={{ marginTop: 4, fontSize: 11, color: '#166534' }}>
+                  El scheduler los enviará a Publer cuando llegue su <code>scheduled_at</code>.
+                </p>
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+
+      {grouped.size === 0 ? (
+        <div className="card-paper" style={{ padding: 32, textAlign: 'center', borderStyle: 'dashed' }}>
+          <p style={{ fontSize: 13, color: 'var(--color-foreground-muted)' }}>
+            El calendar.json está vacío. Añade el primer post en Git.
+          </p>
+        </div>
+      ) : (
+        <section style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+          {Array.from(grouped.entries()).map(([day, dayPosts]) => (
+            <div key={day}>
+              <h2 style={{ margin: '0 0 12px', fontSize: 18, fontFamily: 'var(--font-display)', fontWeight: 700, textTransform: 'capitalize' }}>
+                {fmtDay(day)}
+              </h2>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                {dayPosts.map((post) => (
+                  <PostCard key={post.id} post={post} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      <footer style={{ marginTop: 48, fontSize: 11, color: 'var(--color-foreground-subtle)' }}>
+        <p>Última generación: {data?.generated_at || 'nunca (manual)'}</p>
+        <p style={{ marginTop: 4 }}>
+          Para editar: modifica <code>content/social/calendar.json</code> y abre un PR.
+        </p>
+      </footer>
     </div>
   );
 }

--- a/admin/src/services/socialAPI.js
+++ b/admin/src/services/socialAPI.js
@@ -1,0 +1,16 @@
+const BASE = '/api/social';
+
+export async function fetchSocialCalendar() {
+  const res = await fetch(`${BASE}/calendar`);
+  const data = await res.json().catch(() => ({ ok: false, error: `Error ${res.status}` }));
+  if (!res.ok || data.ok === false) {
+    throw new Error(data.error || `Error ${res.status} al cargar calendar`);
+  }
+  return data;
+}
+
+/** Convierte `public/social/<rest>` → `/assets/social/<rest>` para servir desde el dev server. */
+export function socialAssetUrl(repoRelativePath) {
+  if (!repoRelativePath) return null;
+  return '/assets/social/' + repoRelativePath.replace(/^public\/social\//, '');
+}


### PR DESCRIPTION
## Summary
Wave 2 del Sprint 14: portar la vista del calendar social desde Astro (\`src/pages/admin/social/index.astro\`) al admin React. Reemplaza el placeholder de \`/social\` que llegó con A1.

### Componentes nuevos
- \`src/services/socialAPI.js\` — cliente fetch de \`/api/social/calendar\` (creado en A2) + helper \`socialAssetUrl()\`
- \`src/hooks/useSocialCalendar.js\` — hook con loading/error/refetch
- \`src/components/social/InstagramPreview.jsx\` — mockup IG fiel: header avatar gradiente + username, imagen real con aspect ratio según format (1:1 carousel, 9:16 reel), badge "1/1" o "Reel", action bar (heart/comment/send/save), caption con username bold + hashtags azules, fecha programada
- \`src/pages/SocialCalendarPage.jsx\` — timeline agrupado por día, métricas (5 status), banners (overdueApproved + upcomingApproved), PostCard con badges status/platform/format/locale + toggle "Vista previa Instagram"
- \`src/index.css\` — estilos \`.ig-mock__*\`

### Sprint 14 — Wave 2 cerrada
La página Astro \`/admin/social/\` queda obsoleta; C1 (Wave 3) la borrará y actualizará docs.

## Test plan
- [x] \`pnpm lint\` admin sin errores nuevos en los archivos creados
- [x] \`cd admin && pnpm dev\` → http://localhost:4322/api/social/calendar devuelve 200
- [ ] Abrir http://localhost:4322/social/ → ver timeline con 3 posts (1 approved 2026-05-01, 2 drafts) + click "Vista previa Instagram" en el approved → ver mockup IG con la imagen real
- [ ] Recargar el calendar.json funciona (botón ↻ Recargar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)