### PR TITLE
fix(social-scheduler): window 120min + BOT_PAT + reset post fallido

### DIFF
--- a/.github/workflows/social-scheduler.yml
+++ b/.github/workflows/social-scheduler.yml
@@ -4,8 +4,14 @@ name: Social Scheduler
 # scheduled_at cae dentro de la ventana actual, los envía a Publer
 # para programar/publicar y commitea el calendario actualizado.
 #
-# Cron cada 30 minutos. La ventana del scheduler debe ser >= intervalo
-# del cron para no perder posts (default 30min).
+# Cron cada 30 minutos. Window por defecto 120min para tolerar saltos
+# de runs (GitHub Actions cron puede saltarse 1-2 runs en horas pico).
+#
+# REQUISITO: secret BOT_PAT con un fine-grained PAT del owner del repo
+# scope Contents:write sobre este repo. Necesario porque el bot
+# github-actions[bot] no puede pushear directo a main (branch protection).
+# Si BOT_PAT no está configurado, el workflow usa GITHUB_TOKEN como
+# fallback, lo que probablemente fallará el push pero al menos publicará.
 
 on:
   schedule:
@@ -32,8 +38,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # token con permisos de write para que el push posterior funcione
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT del owner para poder pushear directo a main bypaseando
+          # branch protection. Si no hay BOT_PAT, fallback a GITHUB_TOKEN
+          # (el publish funcionará pero el commit fallará al final).
+          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - uses: actions/setup-node@v6
         with:
@@ -72,4 +81,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add content/social/calendar.json
           git commit -m "chore(social): scheduler $(date -u +%Y-%m-%dT%H:%MZ) — actualizar status"
-          git push
+          # Pull --rebase por si llegó un commit en paralelo (extremadamente raro
+          # con concurrency group, pero defensivo).
+          git pull --rebase origin main || true
+          if ! git push; then
+            echo "::error::Push a main falló — branch protection rechaza al bot."
+            echo "::error::Configura un PAT del owner como secret BOT_PAT (Contents:write sobre este repo)."
+            echo "::error::Ver: docs/SchedulerPubler.md sección 'BOT_PAT setup'."
+            exit 1
+          fi

--- a/content/social/calendar.json
+++ b/content/social/calendar.json
@@ -7,8 +7,8 @@
       "id": "2026-05-04-ig-exercicis-6-anys",
       "platforms": ["instagram"],
       "format": "carousel",
-      "scheduled_at": "2026-05-01T19:00:00+02:00",
-      "status": "approved",
+      "scheduled_at": "2026-05-07T19:00:00+02:00",
+      "status": "draft",
       "locale": "ca",
       "article_slug": "exercicis-futbol-6-anys",
       "target_url": "https://minigolclub.com/ca/ejercicios/exercicis-futbol-6-anys/?utm_source=instagram&utm_medium=carousel&utm_campaign=exercicis-futbol-6-anys",
@@ -30,7 +30,7 @@
           "alt": "Portada — 3 exercicis de futbol per a nens de 6 anys"
         }
       ],
-      "notes": "Hook: 'Si el teu fill de 6 anys es queda parat amb la pilota...'  Carrusel 5 slides: portada + 3 exercicis + CTA",
+      "notes": "RE-PROGRAMADO: el slot original 2026-05-01 19:00 falló (cron GitHub Actions saltó runs + branch protection bloqueó el commit del bot). Aprobar tras configurar BOT_PAT como secret. Carrusel 5 slides: portada + 3 exercicis + CTA",
       "published_at": null,
       "publer_post_id": null
     },
@@ -38,7 +38,7 @@
       "id": "2026-05-04-ig-ejercicios-6-anos",
       "platforms": ["instagram"],
       "format": "carousel",
-      "scheduled_at": "2026-05-01T21:00:00+02:00",
+      "scheduled_at": "2026-05-07T21:00:00+02:00",
       "status": "draft",
       "locale": "es",
       "article_slug": "ejercicios-futbol-ninos-6-anos",

--- a/docs/SchedulerPubler.md
+++ b/docs/SchedulerPubler.md
@@ -190,7 +190,41 @@ Ajustar tras 4 semanas con datos reales del Insights de cada plataforma.
 La API devolvió 200 pero sin job ID — probablemente la cuenta de Publer no tiene permisos para esa plataforma o el account ID es incorrecto. Verifica con `pnpm social:accounts`.
 
 **"stale post ... — marcando failed"**
-El post quedó `approved` con `scheduled_at` >30min en el pasado al evaluar. Posible causa: workflow desactivado por GitHub (los crons en repos públicos sin actividad >60 días se pausan automáticamente). Solución: re-aprobar con nueva fecha futura, o ajustar `--window` si hay outage prolongado.
+El post quedó `approved` con `scheduled_at` más de N min en el pasado (donde N = `--window`, default 120). Causas comunes:
+- Cron de GitHub Actions saltó runs (típico en horas pico — se aceptan saltos de 1-2 runs sin perder posts gracias al window de 120min).
+- Workflow desactivado por GitHub (los crons en repos sin commits 60+ días se pausan automáticamente).
+
+Solución: re-aprobar con nueva fecha futura via admin, o ampliar `--window` si hay outage prolongado.
+
+**"protected branch hook declined" al pushear el calendar actualizado**
+La branch `main` requiere PRs y el bot `github-actions[bot]` no puede pushear directo. **Configurar `BOT_PAT`** (ver siguiente sección).
 
 **Workflow no ejecuta automáticamente**
 GitHub pausa crons en repos sin commits durante 60 días. Cualquier commit a main lo reactiva. Para repos privados con plan free tampoco corren workflows si superas la cuota mensual de minutos.
+
+---
+
+## BOT_PAT setup (requerido para que el scheduler commitee status)
+
+El workflow necesita pushear directo a `main` el `calendar.json` actualizado tras cada publicación. La branch protection lo bloquea para el bot por defecto. Solución: crear un PAT del owner del repo (admin) y guardarlo como secret.
+
+**Pasos (una vez):**
+
+1. Ir a https://github.com/settings/personal-access-tokens (fine-grained tokens)
+2. **Generate new token** con:
+   - **Token name**: `MiniGol Social Scheduler`
+   - **Resource owner**: tu usuario
+   - **Repository access**: Only select repositories → `jatibamoza/webfutbolninos`
+   - **Repository permissions**:
+     - **Contents**: Read and write
+     - **Metadata**: Read (auto)
+   - **Expiration**: 1 año (renovar después)
+3. Copiar el token (`github_pat_...`)
+4. En el repo, ir a Settings → Secrets and variables → Actions → New repository secret:
+   - **Name**: `BOT_PAT`
+   - **Secret**: pegar el PAT
+5. Listo. El próximo cron usará el PAT y podrá commitear bypaseando la branch protection (porque es un token personal con scope contents:write y `enforce_admins=false` permite a admins push directo).
+
+**¿Por qué PAT y no GITHUB_APP?** PAT es 1 paso de setup vs registrar una App. Para 1 workflow es overkill montar una App. Si el repo crece a 5+ workflows que necesitan bypass, considerar migración a GitHub App.
+
+**Si el PAT expira:** los workflows fallarán con "protected branch hook declined". Renovar PAT y actualizar secret. El email de GitHub avisa 7 días antes del expiry.

--- a/scripts/social/scheduler.mjs
+++ b/scripts/social/scheduler.mjs
@@ -22,7 +22,7 @@
  *
  * Flags:
  *   --dry-run    — no llama Publer ni modifica calendar.json. Solo loggea.
- *   --window=N   — minutos hacia atrás considerados "ahora ya". Default 30.
+ *   --window=N   — minutos hacia atrás considerados "ahora ya". Default 120.
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -34,7 +34,10 @@ const CAL_PATH = resolve(process.cwd(), 'content/social/calendar.json');
 const args = new Set(process.argv.slice(2));
 const DRY_RUN = args.has('--dry-run');
 const windowArg = [...args].find((a) => a.startsWith('--window='));
-const WINDOW_MIN = windowArg ? Number(windowArg.split('=')[1]) : 30;
+// Window debe ser >> intervalo del cron para tolerar saltos de runs.
+// GitHub Actions cron puede saltarse 1-2 runs en horas pico.
+// Cron cada 30min + window 120min = tolera 4 runs perdidos.
+const WINDOW_MIN = windowArg ? Number(windowArg.split('=')[1]) : 120;
 
 function log(msg) { console.log(`[scheduler] ${msg}`); }
 function err(msg) { console.error(`[scheduler] ❌ ${msg}`); }


### PR DESCRIPTION
## Why

El primer post programado para 2026-05-01 19:00 **NO se publicó** en Instagram. Causa raíz doble:

1. **Window demasiado corto (30min)**: el cron de GitHub Actions saltó un run en horas pico (gap de 64min entre 16:41 UTC y 17:45 UTC del 1-may). El post estaba scheduled a 17:00 UTC. Cuando el cron de las 17:45 lo agarró, ya era stale (>30min tarde) y el código lo marcó \`failed\` SIN llamar a Publer.

2. **Branch protection bloquea al bot**: aunque el scheduler quisiera registrar cambios en \`calendar.json\`, el push directo del \`github-actions[bot]\` a \`main\` se rechaza con \`protected branch hook declined\`. Por eso desde 1-may hay **34+ runs fallando** seguidos: cada cron lee status=approved (nunca pudo escribir failed), detecta stale, intenta commit, se rechaza, loop.

## Fixes

| # | Cambio | Archivo |
|---|---|---|
| 1 | Window default 30→120 min (tolera 4 runs perdidos del cron) | \`scripts/social/scheduler.mjs\` |
| 2 | Workflow usa secret \`BOT_PAT\` con fallback a \`GITHUB_TOKEN\` + mensaje de error claro si el push falla | \`.github/workflows/social-scheduler.yml\` |
| 3 | Reset del post fallido CA + su gemelo ES: \`approved\`→\`draft\`, scheduled_at a 2026-05-07 19:00/21:00, notes explica el incidente | \`content/social/calendar.json\` |
| 4 | Documentación BOT_PAT setup + troubleshooting actualizado | \`docs/SchedulerPubler.md\` |

## Acción manual del usuario tras merge

**Crear el secret \`BOT_PAT\`** (5 min):
1. https://github.com/settings/personal-access-tokens → Generate new token (fine-grained)
2. Repository: \`jatibamoza/webfutbolninos\` · Permissions: Contents Read+Write · Expiration 1 año
3. Copiar el token, ir a Settings → Secrets and variables → Actions → New repository secret \`BOT_PAT\`
4. Pegar y guardar

Sin BOT_PAT el publish a Publer funcionará (el siguiente paso) pero el commit del status update fallará. Detalles completos en \`docs/SchedulerPubler.md\`.

**Tras BOT_PAT configurado:** aprobar el post 2026-05-07 19:00 desde el admin (cuando PR #63 esté mergeado) o editar calendar.json a mano (status: approved). El cron lo recogerá automáticamente.

## Test plan
- [x] \`pnpm social:validate\` — 6 posts válidos, todos en draft
- [x] \`pnpm social:dry\` — window=120min · 0 due 0 stale (correcto, todo es draft)
- [ ] Tras merge + BOT_PAT: aprobar post de prueba → verificar en GH Actions que el run hace push limpio

🤖 Generated with [Claude Code](https://claude.com/claude-code)