### PR TITLE
feat(admin): editar fecha y hora del post desde el admin

### DIFF
--- a/admin/src/pages/SocialCalendarPage.jsx
+++ b/admin/src/pages/SocialCalendarPage.jsx
@@ -1,8 +1,37 @@
 import { useState } from 'react';
 import { useSocialCalendar } from '../hooks/useSocialCalendar.js';
-import { setPostStatus } from '../services/socialAPI.js';
+import { setPostStatus, setPostScheduledAt } from '../services/socialAPI.js';
 import { toast } from '../services/toast.js';
 import InstagramPreview from '../components/social/InstagramPreview.jsx';
+
+/**
+ * Convierte un ISO con offset (`2026-05-07T19:00:00+02:00`) al formato del input
+ * datetime-local (`2026-05-07T19:00`), preservando los componentes de fecha/hora
+ * tal como aparecen en el ISO (sin convertir a la TZ del navegador).
+ * Nota: ignoramos el offset porque el datetime-local no lo acepta. El offset
+ * lo añadimos al guardar.
+ */
+function isoToDatetimeLocal(iso) {
+  const m = iso.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})(?::\d{2})?/);
+  return m ? `${m[1]}T${m[2]}` : '';
+}
+
+/**
+ * Detecta el offset original del ISO (`+02:00`, `-05:00`, `Z`).
+ * Si no encuentra, devuelve el offset Madrid del momento (CET/CEST según fecha).
+ */
+function detectOffset(iso) {
+  const m = iso.match(/([zZ]|[+-]\d{2}:\d{2})$/);
+  if (m) return m[1] === 'Z' || m[1] === 'z' ? 'Z' : m[1];
+  // Fallback: offset de Madrid en la fecha del ISO (CEST entre 27 mar y 30 oct, CET el resto)
+  const d = new Date(iso);
+  const month = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  const isCEST = (month > 3 && month < 10) ||
+    (month === 3 && day >= 27) ||
+    (month === 10 && day < 30);
+  return isCEST ? '+02:00' : '+01:00';
+}
 
 const STATUS_STYLE = {
   draft:     { bg: '#e5e7eb', fg: '#374151', label: 'Borrador' },
@@ -58,6 +87,8 @@ function previewCaption(caption, max = 140) {
 function PostCard({ post, onChanged }) {
   const [showPreview, setShowPreview] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [editingDate, setEditingDate] = useState(false);
+  const [draftDateTime, setDraftDateTime] = useState(() => isoToDatetimeLocal(post.scheduled_at));
   const status = STATUS_STYLE[post.status] || STATUS_STYLE.draft;
 
   async function changeStatus(nextStatus, confirmMsg) {
@@ -73,6 +104,35 @@ function PostCard({ post, onChanged }) {
     } finally {
       setBusy(false);
     }
+  }
+
+  async function saveDateTime() {
+    if (!draftDateTime) {
+      toast('Fecha/hora vacía', 'error');
+      return;
+    }
+    const offset = detectOffset(post.scheduled_at);
+    const newIso = `${draftDateTime}:00${offset}`;
+    if (newIso === post.scheduled_at) {
+      setEditingDate(false);
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await setPostScheduledAt(post.id, newIso);
+      toast(`Fecha actualizada. ${result.hint || 'Recuerda commit + push.'}`, 'success');
+      setEditingDate(false);
+      onChanged?.();
+    } catch (err) {
+      toast(err.message, 'error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function cancelDateEdit() {
+    setDraftDateTime(isoToDatetimeLocal(post.scheduled_at));
+    setEditingDate(false);
   }
 
   return (
@@ -164,14 +224,71 @@ function PostCard({ post, onChanged }) {
             </span>
           )}
         </div>
-        <time
-          className="mono"
-          style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-foreground-muted)' }}
-          dateTime={post.scheduled_at}
-        >
-          {fmtTime(post.scheduled_at)}
-        </time>
+        {!editingDate && (post.status === 'draft' || post.status === 'approved') ? (
+          <button
+            type="button"
+            onClick={() => setEditingDate(true)}
+            title="Editar fecha y hora"
+            className="mono"
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: 'var(--color-foreground-muted)',
+              background: 'none',
+              border: '1px dashed transparent',
+              borderRadius: 6,
+              padding: '4px 6px',
+              cursor: 'pointer',
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--color-border-strong)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'transparent'; }}
+          >
+            {fmtTime(post.scheduled_at)} ✎
+          </button>
+        ) : !editingDate ? (
+          <time
+            className="mono"
+            style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-foreground-muted)' }}
+            dateTime={post.scheduled_at}
+          >
+            {fmtTime(post.scheduled_at)}
+          </time>
+        ) : null}
       </header>
+
+      {editingDate && (
+        <div style={{ marginTop: 12, padding: 12, background: 'var(--color-surface-alt)', borderRadius: 8, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8 }}>
+          <label className="mono" style={{ fontSize: 11, color: 'var(--color-foreground-muted)' }}>
+            Fecha y hora ({detectOffset(post.scheduled_at)} Madrid):
+          </label>
+          <input
+            type="datetime-local"
+            value={draftDateTime}
+            onChange={(e) => setDraftDateTime(e.target.value)}
+            disabled={busy}
+            className="input"
+            style={{ minHeight: 36, padding: '6px 10px', fontSize: 13, width: 'auto', flex: '0 0 auto' }}
+          />
+          <button
+            type="button"
+            onClick={saveDateTime}
+            disabled={busy}
+            className="btn btn-primary"
+            style={{ minHeight: 36, padding: '6px 12px', fontSize: 13 }}
+          >
+            {busy ? 'Guardando…' : '💾 Guardar'}
+          </button>
+          <button
+            type="button"
+            onClick={cancelDateEdit}
+            disabled={busy}
+            className="btn btn-ghost"
+            style={{ minHeight: 36, padding: '6px 12px', fontSize: 13 }}
+          >
+            Cancelar
+          </button>
+        </div>
+      )}
 
       <p style={{ marginTop: 12, fontSize: 13, lineHeight: 1.5, color: 'var(--color-foreground)', whiteSpace: 'pre-line' }}>
         {previewCaption(post.caption)}

--- a/admin/src/services/socialAPI.js
+++ b/admin/src/services/socialAPI.js
@@ -15,15 +15,18 @@ export function socialAssetUrl(repoRelativePath) {
   return '/assets/social/' + repoRelativePath.replace(/^public\/social\//, '');
 }
 
-export async function setPostStatus(id, status) {
+export async function patchPost(id, patch) {
   const res = await fetch(`${BASE}/calendar/${encodeURIComponent(id)}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ status }),
+    body: JSON.stringify(patch),
   });
   const data = await res.json().catch(() => ({ ok: false, error: `Error ${res.status}` }));
   if (!res.ok || data.ok === false) {
-    throw new Error(data.error || `Error ${res.status} al cambiar status`);
+    throw new Error(data.error || `Error ${res.status} al actualizar el post`);
   }
   return data;
 }
+
+export const setPostStatus = (id, status) => patchPost(id, { status });
+export const setPostScheduledAt = (id, scheduled_at) => patchPost(id, { scheduled_at });

--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -604,19 +604,47 @@ function socialApiMiddleware() {
         const pathParts = url.pathname.split('/').filter(Boolean);
         const VALID_STATUSES = ['draft', 'approved', 'published', 'failed', 'archived'];
 
-        // PATCH /api/social/calendar/:id  →  cambia status del post
+        // PATCH /api/social/calendar/:id  →  cambia status y/o scheduled_at del post.
+        // Body acepta cualquier subset de { status, scheduled_at }.
         if (req.method === 'PATCH' && pathParts[0] === 'calendar' && pathParts[1]) {
           let body = '';
           req.on('data', (chunk) => { body += chunk; });
           req.on('end', () => {
             try {
               const postId = decodeURIComponent(pathParts[1]);
-              const { status: nextStatus } = JSON.parse(body || '{}');
+              const { status: nextStatus, scheduled_at: nextScheduledAt } = JSON.parse(body || '{}');
 
-              if (!VALID_STATUSES.includes(nextStatus)) {
+              if (nextStatus === undefined && nextScheduledAt === undefined) {
+                res.statusCode = 400;
+                res.end(JSON.stringify({ ok: false, error: 'Body debe incluir al menos status o scheduled_at' }));
+                return;
+              }
+
+              if (nextStatus !== undefined && !VALID_STATUSES.includes(nextStatus)) {
                 res.statusCode = 400;
                 res.end(JSON.stringify({ ok: false, error: `status inválido. Válidos: ${VALID_STATUSES.join(', ')}` }));
                 return;
+              }
+
+              // scheduled_at debe ser ISO 8601 con timezone.
+              if (nextScheduledAt !== undefined) {
+                if (typeof nextScheduledAt !== 'string') {
+                  res.statusCode = 400;
+                  res.end(JSON.stringify({ ok: false, error: 'scheduled_at debe ser string ISO 8601 con timezone' }));
+                  return;
+                }
+                const parsed = Date.parse(nextScheduledAt);
+                if (Number.isNaN(parsed)) {
+                  res.statusCode = 400;
+                  res.end(JSON.stringify({ ok: false, error: `scheduled_at no es ISO 8601 válida: ${nextScheduledAt}` }));
+                  return;
+                }
+                // Exigir timezone explícito para evitar ambigüedades UTC vs local del servidor.
+                if (!/[zZ]|[+-]\d{2}:\d{2}$/.test(nextScheduledAt)) {
+                  res.statusCode = 400;
+                  res.end(JSON.stringify({ ok: false, error: 'scheduled_at debe incluir timezone (ej. +02:00 Madrid o Z para UTC)' }));
+                  return;
+                }
               }
 
               if (!fs.existsSync(SOCIAL_CALENDAR_PATH)) {
@@ -636,11 +664,15 @@ function socialApiMiddleware() {
                 return;
               }
 
-              const previousStatus = posts[idx].status;
+              const post = posts[idx];
+              const previousStatus = post.status;
+              const previousScheduledAt = post.scheduled_at;
 
-              // Approve guards: no aprobar si falta asset o el target_url está vacío.
-              if (nextStatus === 'approved') {
-                const post = posts[idx];
+              // Guards al aprobar: media y asset existentes, scheduled_at en futuro.
+              const finalStatus = nextStatus !== undefined ? nextStatus : previousStatus;
+              const finalScheduledAt = nextScheduledAt !== undefined ? nextScheduledAt : previousScheduledAt;
+
+              if (finalStatus === 'approved') {
                 const firstAsset = Array.isArray(post.media) ? post.media[0] : null;
                 if (!firstAsset?.path) {
                   res.statusCode = 422;
@@ -653,28 +685,57 @@ function socialApiMiddleware() {
                   res.end(JSON.stringify({ ok: false, error: `No se puede aprobar: falta el asset ${firstAsset.path}` }));
                   return;
                 }
+                if (Date.parse(finalScheduledAt) < Date.now()) {
+                  res.statusCode = 422;
+                  res.end(JSON.stringify({ ok: false, error: `No se puede aprobar: scheduled_at (${finalScheduledAt}) está en el pasado` }));
+                  return;
+                }
               }
 
-              // Reescribir solo el campo status del post específico, preservando el formato original.
+              // Reescribir solo los campos modificados, preservando el formato original.
               const escapedId = postId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-              const postBlockRe = new RegExp(`("id":\\s*"${escapedId}"[\\s\\S]*?"status":\\s*")(\\w+)(")`);
-              const newRaw = raw.replace(postBlockRe, `$1${nextStatus}$3`);
-              if (newRaw === raw) {
-                res.statusCode = 500;
-                res.end(JSON.stringify({ ok: false, error: 'No se pudo localizar el bloque status del post en el JSON' }));
-                return;
-              }
-              fs.writeFileSync(SOCIAL_CALENDAR_PATH, newRaw, 'utf8');
+              let newRaw = raw;
 
-              const hint = nextStatus === 'approved'
-                ? 'Aprobado localmente. Commit + push de content/social/calendar.json para que el cron lo recoja.'
-                : `Status cambiado a ${nextStatus} localmente. Commit + push para que el cron vea el cambio.`;
+              if (nextStatus !== undefined && nextStatus !== previousStatus) {
+                const re = new RegExp(`("id":\\s*"${escapedId}"[\\s\\S]*?"status":\\s*")(\\w+)(")`);
+                const replaced = newRaw.replace(re, `$1${nextStatus}$3`);
+                if (replaced === newRaw) {
+                  res.statusCode = 500;
+                  res.end(JSON.stringify({ ok: false, error: 'No se pudo localizar el bloque status del post en el JSON' }));
+                  return;
+                }
+                newRaw = replaced;
+              }
+
+              if (nextScheduledAt !== undefined && nextScheduledAt !== previousScheduledAt) {
+                const re = new RegExp(`("id":\\s*"${escapedId}"[\\s\\S]*?"scheduled_at":\\s*")([^"]+)(")`);
+                const replaced = newRaw.replace(re, `$1${nextScheduledAt}$3`);
+                if (replaced === newRaw) {
+                  res.statusCode = 500;
+                  res.end(JSON.stringify({ ok: false, error: 'No se pudo localizar el bloque scheduled_at del post en el JSON' }));
+                  return;
+                }
+                newRaw = replaced;
+              }
+
+              if (newRaw !== raw) {
+                fs.writeFileSync(SOCIAL_CALENDAR_PATH, newRaw, 'utf8');
+              }
+
+              const changes = [];
+              if (nextStatus !== undefined && nextStatus !== previousStatus) changes.push(`status → ${nextStatus}`);
+              if (nextScheduledAt !== undefined && nextScheduledAt !== previousScheduledAt) changes.push(`scheduled_at → ${nextScheduledAt}`);
+              const hint = changes.length > 0
+                ? `${changes.join(', ')} localmente. Commit + push de content/social/calendar.json para que el cron lo vea.`
+                : 'Sin cambios.';
 
               res.end(JSON.stringify({
                 ok: true,
                 id: postId,
                 previousStatus,
-                status: nextStatus,
+                previousScheduledAt,
+                status: finalStatus,
+                scheduled_at: finalScheduledAt,
                 hint,
               }));
             } catch (err) {


### PR DESCRIPTION
## Summary
Antes: si querías cambiar el \`scheduled_at\` de un post tenías que editar \`calendar.json\` a mano. Ahora la hora en cada PostCard es **clickable** (con ✎) → abre un inline editor con \`datetime-local\` + Guardar/Cancelar.

## Cambios

### Backend — \`PATCH /api/social/calendar/:id\`
- Acepta \`{ status, scheduled_at }\` o cualquier subset (antes solo \`status\`)
- Valida \`scheduled_at\` ISO 8601 con TZ obligatorio (rechaza sin offset/Z)
- Guard 422 al aprobar: \`scheduled_at\` no puede estar en el pasado
- Regex preserva formato del JSON (diff de 1 línea por campo)

### UI
- Hora en la card → botón con ✎. Click abre editor inline.
- \`isoToDatetimeLocal()\` y \`detectOffset()\` preservan la TZ original del post (no convierte a la del navegador)
- Solo editable en \`draft\`/\`approved\`. \`published\`/\`failed\`/\`archived\` bloqueados.
- Toast con hint de commit + push

### Cliente
- \`patchPost(id, patch)\` genérico
- \`setPostStatus\`/\`setPostScheduledAt\` como helpers

## Test plan
- [x] PATCH cambio fecha válido → 200, diff 1 línea
- [x] PATCH sin TZ → 400 "scheduled_at debe incluir timezone"
- [x] PATCH ISO inválido → 400
- [x] PATCH approve + fecha pasado → 422
- [x] PATCH revertir fecha → diff vacío (regex preserva formato perfectamente)
- [ ] Tras merge: cd admin && pnpm dev → click la hora de cualquier draft → edita → Guardar → ver el cambio reflejado

🤖 Generated with [Claude Code](https://claude.com/claude-code)