### PR TITLE
fix(admin): layout botón Commitear + colisión de branch

### DIFF
--- a/admin/src/pages/SocialCalendarPage.jsx
+++ b/admin/src/pages/SocialCalendarPage.jsx
@@ -460,7 +460,7 @@ function CommitButton({ onCommitted }) {
       onClick={doCommit}
       disabled={busy}
       className="btn btn-primary"
-      style={{ marginLeft: 12, minHeight: 36, padding: '8px 14px', fontSize: 13 }}
+      style={{ minHeight: 36, padding: '6px 14px', fontSize: 13 }}
       title={summary}
     >
       {busy ? 'Creando PR…' : `📤 Commitear (${diff.changes.length || 'cambios'}) y abrir PR`}
@@ -511,26 +511,28 @@ export default function SocialCalendarPage() {
         </h1>
         <p style={{ marginTop: 12, fontSize: 13, color: 'var(--color-foreground-muted)' }}>
           Lectura de <code style={{ fontFamily: 'var(--font-mono)', padding: '2px 6px', background: 'var(--color-surface-alt)', borderRadius: 4 }}>content/social/calendar.json</code>.{' '}
-          Para editar, modifica el JSON en Git y abre PR.
+          Para editar, abre cada post abajo o usa el botón de commitear cambios.
+        </p>
+        <div style={{ marginTop: 12, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 12 }}>
           <button
             type="button"
             onClick={refetch}
             className="mono"
             style={{
-              marginLeft: 12,
               fontSize: 11,
-              padding: '4px 10px',
+              padding: '6px 12px',
               borderRadius: 6,
               background: 'var(--color-surface-alt)',
               border: 'none',
               cursor: 'pointer',
               color: 'var(--color-foreground)',
+              minHeight: 36,
             }}
           >
             ↻ Recargar
           </button>
           <CommitButton onCommitted={refetch} />
-        </p>
+        </div>
       </header>
 
       <section style={{ marginBottom: 32, display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))' }}>

--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -9,7 +9,10 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import matter from 'gray-matter';
 
-const execFileAsync = promisify(execFile);
+const _execFileAsync = promisify(execFile);
+// windowsHide:true por defecto: workaround del bug Windows STATUS_DLL_INIT_FAILED
+// (0xC0000142) que se dispara al spawning child processes con cwd que contiene "ñ".
+const execFileAsync = (cmd, args, opts) => _execFileAsync(cmd, args, { windowsHide: true, ...opts });
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ARTICULOS_DIR = path.join(__dirname, '..', 'src', 'content', 'articulos');
@@ -827,14 +830,26 @@ function socialApiMiddleware() {
                   return;
                 }
 
-                // Generar branch name único con timestamp UTC
-                const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 16);
-                branchName = `social/admin-update-${ts}`;
+                // Generar branch name único: timestamp completo (con segundos) + sufijo random.
+                const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+                const rand = Math.random().toString(36).slice(2, 8);
+                branchName = `social/admin-update-${ts}-${rand}`;
 
                 // Cleanup worktree previo si quedó
                 if (fs.existsSync(worktreePath)) {
-                  await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], { cwd: REPO_ROOT, windowsHide: true });
+                  try {
+                    await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], { cwd: REPO_ROOT, windowsHide: true });
+                  } catch {
+                    // Si remove falla pero el dir existe, borrarlo a mano + prune
+                    try { await fsp.rm(worktreePath, { recursive: true, force: true }); } catch { /* ignore */ }
+                    try { await execFileAsync('git', ['worktree', 'prune'], { cwd: REPO_ROOT, windowsHide: true }); } catch { /* ignore */ }
+                  }
                 }
+
+                // Cleanup branch local si quedó de un intento previo
+                try {
+                  await execFileAsync('git', ['branch', '-D', branchName], { cwd: REPO_ROOT, windowsHide: true });
+                } catch { /* no existía — OK */ }
 
                 // Worktree desde origin/main actualizado
                 await execFileAsync('git', ['fetch', 'origin', 'main'], { cwd: REPO_ROOT, windowsHide: true });


### PR DESCRIPTION
## Bugs detectados por el usuario tras merge de #70

### Bug 1 — Layout desordenado
El botón "📤 Commitear" aparecía en línea aparte debajo del párrafo del header en lugar de junto a "↻ Recargar". Causa: estaba dentro de un \`<p>\` que rompe el flujo de un botón con padding grande.

**Fix:** extraer Recargar + Commitear a su propio \`<div>\` con flex + gap.

### Bug 2 — "Command failed: git checkout -b ..."
Click en Commitear → backend abre worktree → \`git checkout -b social/admin-update-2026-05-05T09-48\` falla.

Causas combinadas:
- Branch name solo tenía minutos (T09-48). 2 clicks en el mismo minuto = colisión
- Cleanup en catch borraba worktree pero NO la branch local fantasma → ciclo infinito
- Algunas execFile no tenían \`windowsHide:true\` (no estaban cubiertas por mi replace_all anterior). Mismo bug Windows con cwd que contiene "ñ" (\`STATUS_DLL_INIT_FAILED\`)

**Fixes:**
- Branch name con timestamp completo (segundos) + sufijo random 6 chars → colisión prácticamente imposible
- Cleanup defensivo al inicio del endpoint: borra branch local fantasma + \`rm -rf\` worktree dir + \`git worktree prune\` si \`worktree remove\` falló
- Wrapper de \`execFileAsync\` que aplica \`windowsHide:true\` por defecto a TODAS las llamadas (también arregla silenciosamente /publicar artículos que tenía el mismo bug)

## Test plan
- [ ] Tras merge: 1 click Commitear → PR se crea sin errores
- [ ] 2 clicks rápidos seguidos → ambos crean PRs distintos (o el segundo dice "no hay cambios" si el primero ya pusheó)
- [ ] Layout: botón sale en línea junto a "↻ Recargar"

🤖 Generated with [Claude Code](https://claude.com/claude-code)