### PR TITLE
fix(admin): commit endpoint usa checkout completo del worktree

### DIFF
--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -851,15 +851,17 @@ function socialApiMiddleware() {
                   await execFileAsync('git', ['branch', '-D', branchName], { cwd: REPO_ROOT, windowsHide: true });
                 } catch { /* no existía — OK */ }
 
-                // Worktree desde origin/main actualizado
-                await execFileAsync('git', ['fetch', 'origin', 'main'], { cwd: REPO_ROOT, windowsHide: true });
-                await execFileAsync('git', ['worktree', 'add', '--no-checkout', worktreePath, 'origin/main'], { cwd: REPO_ROOT, windowsHide: true });
+                // Worktree desde origin/main con CHECKOUT COMPLETO (sin --no-checkout).
+                // Necesitamos checkout completo porque vamos a MODIFICAR un archivo
+                // existente (calendar.json). Si dejáramos el worktree vacío, el
+                // commit resultante eliminaría todos los demás archivos del repo
+                // (tree construido desde index vacío).
+                await execFileAsync('git', ['fetch', 'origin', 'main'], { cwd: REPO_ROOT });
+                await execFileAsync('git', ['worktree', 'add', '-b', branchName, worktreePath, 'origin/main'], { cwd: REPO_ROOT });
                 worktreeCreated = true;
-
-                await execFileAsync('git', ['checkout', '-b', branchName], { cwd: worktreePath });
                 branchCreated = true;
 
-                // Copiar el calendar.json LOCAL (con los cambios) al worktree
+                // Sobrescribir calendar.json con la versión local (con los cambios)
                 const destCalendar = path.join(worktreePath, 'content', 'social', 'calendar.json');
                 await fsp.copyFile(SOCIAL_CALENDAR_PATH, destCalendar);
 


### PR DESCRIPTION
## Bug
Al hacer click en "📤 Commitear" desde admin: \`ENOENT: no such file or directory, copyfile 'content/social/calendar.json' → 'mg-pr-tmp/content/social/...'\`.

## Causa raíz (peor de lo que parecía)
El worktree se creaba con \`--no-checkout\` (replicando el patrón de \`/api/articulos/:slug/publicar\`). Eso deja el worktree dir VACÍO — sin archivos, sin índice. El dir \`content/social/\` no existía → \`copyFile\` falló.

**Pero el bug real era más grave:** incluso añadiendo \`fsp.mkdir\` defensivo, el commit resultante habría tenido el index con SOLO \`calendar.json\` (porque el index también está vacío con --no-checkout). El tree del nuevo commit sería un único archivo. Como parent=origin/main, el PR habría mostrado **todos los demás archivos del repo como deleted** (ArticleCard, todos los .mdx, etc.). Catástrofe.

(El endpoint /publicar de artículos no sufre este bug porque crea archivos NUEVOS: el commit "added" se ve normal incluso si el index solo tiene esos 2 archivos. Para una MODIFICACIÓN como la nuestra, el patrón rompe.)

## Fix
Cambiar a \`git worktree add -b branchName worktreePath origin/main\` (sin --no-checkout). Esto:
1. Crea el worktree con CHECKOUT COMPLETO de todos los archivos de origin/main
2. Crea la branch en un solo paso (elimina el \`git checkout -b\` redundante)

Luego sobrescribimos calendar.json con la versión local. \`git add\` + \`git commit\` produce un diff limpio: 1 línea cambiada. PR limpio.

## Test plan
- [ ] Tras merge: 1 cambio en admin → click Commitear → PR creado con SOLO el calendar.json modificado (nada deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)