### PR TITLE
chore: añadir public/ads.txt para AdSense

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,9 @@
 # Google Analytics 4
 PUBLIC_GA_ID=
 
-# Google AdSense (publisher ID, ej. ca-pub-XXXXXXXXXXXXXXXX)
+# Google AdSense (publisher ID con prefijo ca-, ej. ca-pub-XXXXXXXXXXXXXXXX)
+# En producción esta var se configura en Cloudflare Workers (Settings → Variables).
+# El archivo public/ads.txt debe actualizarse en paralelo con el mismo pub ID (sin el prefijo ca-).
 PUBLIC_ADSENSE_CLIENT=
 
 # Amazon Afiliados (tracking tag, ej. minigolclub-21)

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6437753169446450, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Why
AdSense → Sitios reportaba \`Estado del archivo ads.txt: No encontrado\` para minigolclub.com. Sin ads.txt:
- Algunos buyers no licitan (pérdida de revenue)
- La aprobación AdSense puede ralentizarse
- Riesgo de fraude reportado al sitio

## Cambios
- \`public/ads.txt\` con la línea estándar:
  \`\`\`
  google.com, pub-6437753169446450, DIRECT, f08c47fec0942fa0
  \`\`\`
  (\`f08c47fec0942fa0\` es el TAG ID de Google, fijo para todos los AdSense publishers)
- \`.env.example\`: comentario actualizado explicando que en prod la var \`PUBLIC_ADSENSE_CLIENT\` se setea en Cloudflare Workers y debe ir en sync con \`ads.txt\`

## Después del merge
1. Cloudflare Workers deploya automático en ~30s
2. Verificar \`curl https://minigolclub.com/ads.txt\` devuelve 200 con la línea
3. Esperar ≤48h a que Google re-escanee. Estado en AdSense → Sitios pasa a \`Encontrado\`

## Acción separada (verificar)
Confirmar que \`PUBLIC_ADSENSE_CLIENT=ca-pub-6437753169446450\` está como env var en Cloudflare Workers (Settings → Variables del Worker minigolclub). Si no está, el script de AdSense no se carga en producción aunque la aprobación llegue. Para verificar:

\`\`\`bash
curl -s https://minigolclub.com/ | grep -o 'ca-pub-[0-9]*' | head -1
\`\`\`

Si responde \`ca-pub-6437753169446450\`, está bien. Si vacío, hay que añadir la var en Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)