### PR TITLE
feat(admin): auto-merge del PR de Commitear cuando CI pase

### DIFF
--- a/admin/src/pages/SocialCalendarPage.jsx
+++ b/admin/src/pages/SocialCalendarPage.jsx
@@ -443,7 +443,10 @@ function CommitButton({ onCommitted }) {
     setBusy(true);
     try {
       const result = await commitCalendar();
-      toast(`PR #${result.prNumber} creado`, 'success');
+      const msg = result.autoMergeQueued
+        ? `PR #${result.prNumber} creado y encolado para auto-merge cuando CI pase (~3-4min)`
+        : `PR #${result.prNumber} creado — mergéalo manualmente`;
+      toast(msg, 'success');
       window.open(result.prUrl, '_blank', 'noopener');
       await refresh();
       onCommitted?.();

--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -892,8 +892,32 @@ function socialApiMiddleware() {
                 const prUrl = prOut.trim();
                 const prNumber = prUrl.match(/\/pull\/(\d+)$/)?.[1];
 
+                // Encolar auto-merge: GitHub mergea cuando todos los CI checks pasen.
+                // Si CI falla, el PR queda abierto para revisión manual (red de seguridad).
+                let autoMergeQueued = false;
+                if (prNumber) {
+                  try {
+                    await execFileAsync(
+                      'gh',
+                      ['pr', 'merge', String(prNumber), '--auto', '--squash', '--delete-branch'],
+                      { cwd: worktreePath },
+                    );
+                    autoMergeQueued = true;
+                  } catch (err) {
+                    // No bloquear: el PR está creado igual, solo no quedó en auto-merge.
+                    console.error(`[social-commit] auto-merge queue falló: ${err.message}`);
+                  }
+                }
+
                 await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], { cwd: REPO_ROOT, windowsHide: true });
-                res.end(JSON.stringify({ ok: true, hasChanges: true, branch: branchName, prUrl, prNumber: prNumber ? parseInt(prNumber, 10) : null }));
+                res.end(JSON.stringify({
+                  ok: true,
+                  hasChanges: true,
+                  branch: branchName,
+                  prUrl,
+                  prNumber: prNumber ? parseInt(prNumber, 10) : null,
+                  autoMergeQueued,
+                }));
               } catch (err) {
                 if (worktreeCreated && fs.existsSync(worktreePath)) {
                   try { await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], { cwd: REPO_ROOT, windowsHide: true }); } catch { /* ignore */ }


### PR DESCRIPTION
## Causa raíz del no-publish del 6-may
El botón "📤 Commitear" creó PR #74 correctamente, pero el usuario olvidó mergearlo. Resultado: calendar de main siguió con todo en draft → cron nunca vio nada due → slot talla-pilota 18:30 pasó vacío sin publicación a Instagram.

## Fix
Tras \`gh pr create\` añadir:
\`\`\`
gh pr merge <num> --auto --squash --delete-branch
\`\`\`
GitHub mergea automáticamente cuando **todos** los CI checks pasen (~3-4min).

**Red de seguridad:** si CI falla, el PR queda abierto para revisión manual. No metemos cambios rotos a main por error.

**Pre-requisito ya activado:** \`allow_auto_merge=true\` en el repo (lo hice via \`gh api PATCH\` antes de este PR).

## UI
El toast del botón Commitear distingue:
- ✅ "PR #N creado y encolado para auto-merge cuando CI pase (~3-4min)"
- ⚠️ "PR #N creado — mergéalo manualmente" (fallback si \`gh pr merge --auto\` falla)

## Flujo nuevo end-to-end
1. Usuario aprueba post en admin
2. Click "📤 Commitear" → backend crea PR + lo encola para auto-merge
3. CI corre (~3-4min) → si verde, GitHub mergea automático
4. Cron del scheduler recoge el cambio en próximo run (max 30min)
5. Publer publica a Instagram a la hora scheduled

**Cero acción humana entre paso 2 y paso 5.** A prueba de olvidos.

## Test plan
- [x] Lint OK
- [ ] Tras merge: aprobar un post → click Commitear → ver toast con "auto-merge cuando CI pase" → verificar en GitHub que el PR queda con la etiqueta "auto-merge enabled" → CI verde → merge automático

🤖 Generated with [Claude Code](https://claude.com/claude-code)