### PR TITLE
fix(social-scheduler): commitear calendar.json también en fallos

### DIFF
--- a/.github/workflows/social-scheduler.yml
+++ b/.github/workflows/social-scheduler.yml
@@ -71,7 +71,10 @@ jobs:
           fi
 
       - name: Commit cambios en calendar.json
-        if: ${{ inputs.dry_run != true }}
+        # always() para que tras un fallo de Publer también persistamos
+        # los cambios de status (failed/error) en el calendar y no quede
+        # un post zombi reintentando cada 30min hasta caer fuera del window.
+        if: ${{ always() && inputs.dry_run != true }}
         run: |
           if git diff --quiet content/social/calendar.json; then
             echo "Sin cambios — nada que commitear."


### PR DESCRIPTION
## Resumen
Cuando Publer devuelve error (caso real hoy: cuenta IG desconectada → 500), el step \`Commit cambios en calendar.json\` se saltaba por el \`exit 1\` del scheduler. Resultado: posts en \`status:approved\` zombi, reintentando cada 30min hasta caer fuera del window de 120min.

Cambio: añadir \`if: \${{ always() && inputs.dry_run != true }}\` al step de commit. El scheduler ya escribe el calendar con \`status:failed\` y el \`error\` antes de hacer \`exit 1\`, así que con \`always()\` ese commit sí llega a main y el siguiente cron ya no reintenta.

## Test plan
- [x] Verificado en logs: la única corrida fallida hoy (run 25568995983) escribió 2 posts a \`failed\` en disco pero el commit fue skipped.
- [ ] Tras merge: próximo cron que tenga fallos debería commitear el calendar (aunque el job termine en failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)