### PR TITLE
fix(adsense): cargar adsbygoogle.js eager para que el crawler lo encuentre

### DIFF
--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -1,13 +1,11 @@
 ---
-import { GA_ID, ADSENSE_CLIENT } from '@/consts';
+import { GA_ID } from '@/consts';
 ---
 
-<script define:vars={{ GA_ID, ADSENSE_CLIENT }}>
-  // Dynamic loaders idempotentes — solo se ejecutan si el usuario acepta la
-  // categoría correspondiente. La primera carga inyecta el <script>, las
-  // siguientes son no-op (flag en window). Compatible con el patrón de
-  // adsbygoogle.push({}) en AdSlot: el array acumula pushes hasta que el
-  // script de adsense carga y los procesa.
+<script define:vars={{ GA_ID }}>
+  // gtag/js sigue siendo lazy: lo cargamos solo si el user acepta analytics.
+  // adsbygoogle.js está eager en BaseLayout.astro porque el crawler de AdSense
+  // no acepta cookies y necesita encontrarlo en el HTML inicial.
   function loadGtag() {
     if (window.__mgGtagLoaded) return;
     window.__mgGtagLoaded = true;
@@ -19,19 +17,8 @@ import { GA_ID, ADSENSE_CLIENT } from '@/consts';
     window.gtag('config', GA_ID, { anonymize_ip: true });
   }
 
-  function loadAdsense() {
-    if (!ADSENSE_CLIENT || window.__mgAdsenseLoaded) return;
-    window.__mgAdsenseLoaded = true;
-    const s = document.createElement('script');
-    s.async = true;
-    s.crossOrigin = 'anonymous';
-    s.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=' + ADSENSE_CLIENT;
-    document.head.appendChild(s);
-  }
-
-  // Exponer para llamarlas desde el módulo del banner (que es ESM async).
+  // Exponer para llamarla desde el módulo del banner (que es ESM async).
   window.__mgLoadGtag = loadGtag;
-  window.__mgLoadAdsense = loadAdsense;
 </script>
 
 <script>
@@ -42,9 +29,7 @@ import { GA_ID, ADSENSE_CLIENT } from '@/consts';
     interface Window {
       gtag: (...args: unknown[]) => void;
       __mgLoadGtag: () => void;
-      __mgLoadAdsense: () => void;
       __mgGtagLoaded?: boolean;
-      __mgAdsenseLoaded?: boolean;
     }
   }
 
@@ -52,8 +37,9 @@ import { GA_ID, ADSENSE_CLIENT } from '@/consts';
     const analytics = categories.includes('analytics');
     const ads = categories.includes('ads');
 
-    // Update Consent Mode v2 — base de Google para que cualquier script
-    // gtag/adsense que ya esté cargado respete el cambio en caliente.
+    // Update Consent Mode v2 — adsbygoogle.js (eager en <head>) respeta este
+    // estado: con ad_storage=denied no setea cookies de personalización ni
+    // tracked ads. Con granted activa la personalización.
     window.gtag('consent', 'update', {
       analytics_storage: analytics ? 'granted' : 'denied',
       ad_storage: ads ? 'granted' : 'denied',
@@ -61,10 +47,8 @@ import { GA_ID, ADSENSE_CLIENT } from '@/consts';
       ad_personalization: ads ? 'granted' : 'denied',
     });
 
-    // Cargar los scripts solo si el usuario aceptó la categoría.
-    // Si rechaza después, el script queda cargado pero gtag respeta el denied.
+    // gtag/js sigue siendo opt-in: solo se inyecta si el user acepta analytics.
     if (analytics) window.__mgLoadGtag();
-    if (ads) window.__mgLoadAdsense();
   }
 
   await CookieConsent.run({

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -91,9 +91,8 @@ const fullTitle = title === SITE.name ? title : `${title} · ${SITE.name}`;
 
     <slot name="head" />
 
-    <!-- Consent Mode v2: defaults denied. Los scripts gtag/js y adsbygoogle.js
-         NO cargan hasta que el usuario acepte cookies via CookieBanner (RGPD +
-         beneficio LCP). El inline aquí es lo único que se ejecuta eager. -->
+    <!-- Consent Mode v2: defaults denied. DEBE ejecutarse antes que cualquier
+         script de Google para que respeten el estado de consentimiento por defecto. -->
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
@@ -105,6 +104,19 @@ const fullTitle = title === SITE.name ? title : `${title} · ${SITE.name}`;
         wait_for_update: 500,
       });
     </script>
+
+    <!-- AdSense verification + bootstrap. DEBE estar eager en <head> para que
+         el crawler de AdSense (Mediapartners-Google, no acepta cookies) lo
+         encuentre y pueda activar el sitio. La privacidad la garantiza el
+         Consent Mode v2 de arriba: el script carga pero NO setea cookies de
+         personalización ni muestra ads tracked hasta que ad_storage=granted. -->
+    {ADSENSE_CLIENT && (
+      <script
+        async
+        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
+        crossorigin="anonymous"
+      ></script>
+    )}
   </head>
   <body class="min-h-screen bg-background text-foreground">
     <a


### PR DESCRIPTION
## Resumen
Causa raíz del rechazo de AdSense: el script \`adsbygoogle.js\` se inyectaba lazy tras click en el CookieBanner. El crawler de AdSense (Mediapartners-Google) no acepta cookies → nunca veía el snippet → no podía verificar el sitio.

## Fix
- Mover el \`<script async src=...adsbygoogle.js?client=ca-pub-...>\` a eager en \`<head>\` de [BaseLayout.astro](src/layouts/BaseLayout.astro).
- Eliminar \`loadAdsense()\` y el flag \`__mgAdsenseLoaded\` del [CookieBanner.astro](src/components/CookieBanner.astro).
- \`gtag/js\` sigue siendo lazy (no afecta a AdSense activation).

## Por qué sigue siendo RGPD-compliant
Consent Mode v2 ya está configurado con \`denied\` defaults ANTES del script. \`adsbygoogle.js\` respeta esos flags en runtime:
- Sin consentimiento: carga pero NO setea cookies de personalización ni muestra ads tracked.
- Con consentimiento: activa personalización completa.

Es el patrón que Google [recomienda oficialmente](https://support.google.com/adsense/answer/7532444).

## Trade-off honesto
LCP subirá ~300-800ms (revertimos parcialmente Sprint 7 P1). Sin AdSense aprobado el LCP perfecto es irrelevante. Si Lighthouse rompe, mitigaciones disponibles: \`loading=lazy\` en cada \`AdSlot\`, bajar threshold perf temporalmente.

## Próximos pasos del operador
1. Mergear este PR.
2. Esperar deploy de Cloudflare (auto, ~1 min).
3. Esperar 24h para que Google re-crawlee.
4. AdSense → Sitios → minigolclub.com → "Solicitar revisión".
5. Google revisa en 1-14 días.

## Test plan
- [x] \`pnpm typecheck\` → 0 errores 0 warnings.
- [ ] Tras merge: comprobar en \`view-source\` de minigolclub.com que el \`<script src=...adsbygoogle.js...>\` aparece en \`<head>\`.
- [ ] Lighthouse CI debe seguir verde (>= 0.90 perf). Si baja, ajustar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)