### PR TITLE
feat(mundial-2026): página educativa pre-torneo + encuesta de campeón

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,11 +16,12 @@ const currentPath = Astro.url.pathname;
 const locale = (Astro.currentLocale ?? 'es') as Locale;
 const t = useTranslations(locale);
 
-const navLabelKey: Record<string, 'nav-ejercicios' | 'nav-juegos' | 'nav-equipamiento' | 'nav-iniciacion' | 'nav-recursos'> = {
+const navLabelKey: Record<string, 'nav-ejercicios' | 'nav-juegos' | 'nav-equipamiento' | 'nav-iniciacion' | 'nav-mundial' | 'nav-recursos'> = {
   '/ejercicios/': 'nav-ejercicios',
   '/juegos/': 'nav-juegos',
   '/equipamiento/': 'nav-equipamiento',
   '/iniciacion/': 'nav-iniciacion',
+  '/mundial-2026/': 'nav-mundial',
   '/recursos/': 'nav-recursos',
 };
 ---
@@ -50,8 +51,16 @@ const navLabelKey: Record<string, 'nav-ejercicios' | 'nav-juegos' | 'nav-equipam
         {
           NAV_PRIMARY.map((item) => {
             const isActive = currentPath.startsWith(item.href);
+            const isFeatured = 'featured' in item && item.featured === true;
             const labelKey = navLabelKey[item.href as keyof typeof navLabelKey];
             const label = labelKey ? t(labelKey) : item.label;
+            // Punto a la derecha: amarillo si la página está activa, rojo si es
+            // entrada destacada (Mundial). Activa gana sobre destacada para no duplicar.
+            const dotColor = isActive
+              ? 'var(--color-accent)'
+              : isFeatured
+                ? 'var(--color-energy)'
+                : null;
             return (
               <li>
                 <a
@@ -63,10 +72,10 @@ const navLabelKey: Record<string, 'nav-ejercicios' | 'nav-juegos' | 'nav-equipam
                   aria-current={isActive ? 'page' : undefined}
                 >
                   {label}
-                  {isActive && (
+                  {dotColor && (
                     <span
                       class="ml-2 inline-block h-1.5 w-1.5 rounded-full"
-                      style="background: var(--color-accent);"
+                      style={`background: ${dotColor};`}
                       aria-hidden="true"
                     ></span>
                   )}
@@ -121,6 +130,7 @@ const navLabelKey: Record<string, 'nav-ejercicios' | 'nav-juegos' | 'nav-equipam
         {
           NAV_PRIMARY.map((item) => {
             const isActive = currentPath.startsWith(item.href);
+            const isFeatured = 'featured' in item && item.featured === true;
             const labelKey = navLabelKey[item.href as keyof typeof navLabelKey];
             const label = labelKey ? t(labelKey) : item.label;
             return (
@@ -131,7 +141,16 @@ const navLabelKey: Record<string, 'nav-ejercicios' | 'nav-juegos' | 'nav-equipam
                   style={`color: ${isActive ? 'var(--color-foreground)' : 'var(--color-foreground-muted)'}; background: ${isActive ? 'var(--color-surface-alt)' : 'transparent'};`}
                   aria-current={isActive ? 'page' : undefined}
                 >
-                  <span class="display text-base font-semibold">{label}</span>
+                  <span class="display text-base font-semibold inline-flex items-center gap-2">
+                    {label}
+                    {isFeatured && !isActive && (
+                      <span
+                        class="inline-block h-2 w-2 rounded-full"
+                        style="background: var(--color-energy);"
+                        aria-hidden="true"
+                      ></span>
+                    )}
+                  </span>
                   <Icon name="lucide:chevron-right" class="h-4 w-4 opacity-50" aria-hidden="true" />
                 </a>
               </li>

--- a/src/components/mundial/CalendarioHitos.astro
+++ b/src/components/mundial/CalendarioHitos.astro
@@ -1,0 +1,188 @@
+---
+import { MUNDIAL_2026, daysToKickoff } from '@/lib/mundial/dates';
+import { fmtDate } from '@/lib/mundial/format';
+
+/**
+ * Timeline vertical con los 8 hitos del Mundial. Cada hito tiene fecha,
+ * nombre y microcopy infantil. Marca cuál ya pasó y cuál es el próximo.
+ *
+ * Calculado en SSR/SSG: la página se rebuildea cada push, por lo que
+ * "próximo hito" no es 100% en tiempo real, pero sí lo suficientemente
+ * cerca para no engañar al niño que entra en mayo y ve "faltan 25 días".
+ */
+
+const now = new Date();
+const dias = daysToKickoff(now);
+const hitos = MUNDIAL_2026.hitos.map((h) => ({
+  ...h,
+  pasado: h.fecha.getTime() < now.getTime(),
+}));
+const proximoIdx = hitos.findIndex((h) => !h.pasado);
+---
+
+<section class="cal" aria-labelledby="cal-titulo">
+  <div class="cal__header">
+    <span class="mono cal__eyebrow">04 · CALENDARIO</span>
+    <h2 id="cal-titulo" class="display cal__titulo">
+      Las <span class="marker">fechas clave</span> del torneo
+    </h2>
+    <p class="cal__intro">
+      Del <strong>11 de junio</strong> al <strong>19 de julio</strong> de 2026. Más de un mes de
+      fútbol sin parar. Apunta estas fechas en el calendario de la nevera.
+    </p>
+    {dias > 0 && (
+      <p class="hand cal__countdown" aria-live="polite">
+        faltan <strong>{dias}</strong> {dias === 1 ? 'día' : 'días'} para la inauguración
+      </p>
+    )}
+  </div>
+
+  <ol class="cal__timeline" role="list">
+    {hitos.map((h, i) => (
+      <li
+        class="cal__hito"
+        data-pasado={h.pasado ? 'true' : 'false'}
+        data-proximo={i === proximoIdx ? 'true' : 'false'}
+      >
+        <div class="cal__marca" aria-hidden="true">
+          <span class="cal__punto"></span>
+        </div>
+        <div class="card-paper cal__card">
+          <time class="mono cal__fecha" datetime={h.fecha.toISOString()}>
+            {fmtDate(h.fecha)}
+          </time>
+          <h3 class="display cal__nombre">{h.nombre}</h3>
+          <p class="cal__desc">{h.descripcion}</p>
+          {i === proximoIdx && (
+            <span class="hand cal__badge">¡es el próximo!</span>
+          )}
+        </div>
+      </li>
+    ))}
+  </ol>
+</section>
+
+<style>
+  .cal {
+    margin-top: 56px;
+  }
+  .cal__header {
+    max-width: 60ch;
+    margin-bottom: 24px;
+  }
+  .cal__eyebrow {
+    display: inline-block;
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    color: var(--color-foreground-subtle);
+    margin-bottom: 8px;
+  }
+  .cal__titulo {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    margin: 0 0 14px;
+  }
+  .cal__intro {
+    color: var(--color-foreground-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    margin: 0;
+  }
+  .cal__countdown {
+    font-size: 24px;
+    color: var(--color-energy);
+    margin: 12px 0 0;
+    transform: rotate(-2deg);
+    transform-origin: left center;
+    display: inline-block;
+  }
+  .cal__countdown strong {
+    background-image: linear-gradient(180deg, transparent 60%, var(--color-marker) 60%, var(--color-marker) 92%, transparent 92%);
+    padding: 0 0.1em;
+  }
+
+  .cal__timeline {
+    list-style: none;
+    padding: 0;
+    margin: 22px 0 0;
+    position: relative;
+  }
+  .cal__timeline::before {
+    content: '';
+    position: absolute;
+    left: 13px;
+    top: 12px;
+    bottom: 12px;
+    width: 2px;
+    background: repeating-linear-gradient(
+      to bottom,
+      var(--color-border-strong) 0,
+      var(--color-border-strong) 4px,
+      transparent 4px,
+      transparent 8px
+    );
+  }
+  .cal__hito {
+    display: grid;
+    grid-template-columns: 28px 1fr;
+    gap: 14px;
+    padding-bottom: 14px;
+  }
+  .cal__marca {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 18px;
+  }
+  .cal__punto {
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    background: var(--color-background);
+    border: 2.5px solid var(--color-border-strong);
+    z-index: 1;
+  }
+  .cal__hito[data-pasado='true'] .cal__punto {
+    background: var(--color-foreground-subtle);
+    border-color: var(--color-foreground-subtle);
+  }
+  .cal__hito[data-proximo='true'] .cal__punto {
+    background: var(--color-energy);
+    border-color: var(--color-energy);
+    box-shadow: 0 0 0 4px color-mix(in oklab, var(--color-energy), transparent 80%);
+  }
+  .cal__card {
+    padding: 14px 18px;
+    position: relative;
+  }
+  .cal__hito[data-pasado='true'] .cal__card {
+    opacity: 0.6;
+  }
+  .cal__fecha {
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    color: var(--color-foreground-subtle);
+    text-transform: uppercase;
+  }
+  .cal__nombre {
+    font-size: 1.15rem;
+    margin: 4px 0 6px;
+  }
+  .cal__desc {
+    margin: 0;
+    color: var(--color-foreground-muted);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+  .cal__badge {
+    position: absolute;
+    top: -10px;
+    right: 14px;
+    background: var(--color-paper);
+    color: var(--color-handwritten);
+    font-size: 20px;
+    padding: 2px 12px;
+    border-radius: 999px;
+    border: 1px dashed var(--color-handwritten);
+    transform: rotate(-4deg);
+  }
+</style>

--- a/src/components/mundial/ComoFunciona.astro
+++ b/src/components/mundial/ComoFunciona.astro
@@ -1,0 +1,184 @@
+---
+/**
+ * "Cómo funciona": camino del Mundial 2026 explicado paso a paso.
+ * Embudo visual 48→32→16→8→4→2→1 con descripción para niños.
+ * Mobile-first: stack vertical. Desktop: pasos horizontales con flecha entre cada uno.
+ */
+
+const fases = [
+  {
+    n: '48',
+    titulo: 'Fase de grupos',
+    descripcion: 'Los 48 equipos se reparten en 12 grupos de 4. Cada equipo juega 3 partidos.',
+    color: 'var(--color-energy)',
+  },
+  {
+    n: '32',
+    titulo: 'Dieciseisavos',
+    descripcion: 'Pasan los 2 primeros de cada grupo + los 8 mejores terceros. ¡Ya hay eliminatorias!',
+    color: 'var(--color-accent)',
+  },
+  {
+    n: '16',
+    titulo: 'Octavos de final',
+    descripcion: 'Si pierdes, te vas a casa. Si ganas, sigues. Sin segundas oportunidades.',
+    color: 'var(--color-info)',
+  },
+  {
+    n: '8',
+    titulo: 'Cuartos de final',
+    descripcion: 'Los 8 mejores del mundo se juegan el pase a semifinales.',
+    color: 'var(--color-secondary)',
+  },
+  {
+    n: '4',
+    titulo: 'Semifinales',
+    descripcion: 'Solo quedan 4. Dos ganan y juegan la final. Dos pierden y juegan por el bronce.',
+    color: 'var(--color-primary)',
+  },
+  {
+    n: '2',
+    titulo: 'La gran final',
+    descripcion: 'El día más esperado. Un solo partido decide quién es el nuevo campeón del mundo.',
+    color: 'var(--color-fun)',
+  },
+  {
+    n: '1',
+    titulo: '¡Campeón!',
+    descripcion: 'Levanta la copa más famosa del fútbol. La próxima vez será en 2030.',
+    color: 'var(--color-energy)',
+    final: true,
+  },
+];
+---
+
+<section class="como" aria-labelledby="como-titulo">
+  <div class="como__header">
+    <span class="mono como__eyebrow">02 · CAMINO AL CAMPEÓN</span>
+    <h2 id="como-titulo" class="display como__titulo">
+      ¿Cómo se llega a <span class="marker">levantar la copa</span>?
+    </h2>
+    <p class="como__intro">
+      De los 48 equipos que empiezan, solo uno gana. El camino tiene <strong>7 fases</strong>.
+      Mira cómo se va reduciendo el grupo en cada parada.
+    </p>
+  </div>
+
+  <ol class="como__lista" role="list">
+    {fases.map((f, i) => (
+      <li class="como__paso card-paper" style={`--paso-color:${f.color};`}>
+        <span class="display como__numero" aria-hidden="true">{f.n}</span>
+        <div class="como__contenido">
+          <span class="mono como__step">FASE {String(i + 1).padStart(2, '0')}</span>
+          <h3 class="display como__paso-titulo">{f.titulo}</h3>
+          <p class="como__paso-desc">{f.descripcion}</p>
+        </div>
+        {!f.final && (
+          <span class="como__flecha" aria-hidden="true">↓</span>
+        )}
+        {f.final && (
+          <span class="hand como__final" aria-hidden="true">¡el más grande!</span>
+        )}
+      </li>
+    ))}
+  </ol>
+</section>
+
+<style>
+  .como {
+    margin-top: 56px;
+  }
+  .como__header {
+    max-width: 60ch;
+    margin-bottom: 24px;
+  }
+  .como__eyebrow {
+    display: inline-block;
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    color: var(--color-foreground-subtle);
+    margin-bottom: 8px;
+  }
+  .como__titulo {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    margin: 0 0 14px;
+  }
+  .como__intro {
+    color: var(--color-foreground-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    margin: 0;
+  }
+  .como__lista {
+    list-style: none;
+    padding: 0;
+    margin: 22px 0 0;
+    display: grid;
+    gap: 14px;
+  }
+  .como__paso {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 18px;
+    padding: 18px 20px;
+    border-left: 4px solid var(--paso-color);
+  }
+  .como__numero {
+    font-size: clamp(2.5rem, 6vw, 3.25rem);
+    line-height: 0.9;
+    color: var(--paso-color);
+    min-width: 80px;
+    text-align: center;
+  }
+  .como__contenido {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .como__step {
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    color: var(--color-foreground-subtle);
+  }
+  .como__paso-titulo {
+    font-size: 1.25rem;
+    margin: 0;
+    line-height: 1.15;
+  }
+  .como__paso-desc {
+    margin: 4px 0 0;
+    color: var(--color-foreground-muted);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+  .como__flecha {
+    position: absolute;
+    bottom: -18px;
+    left: 50px;
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    background: var(--color-background);
+    border: 1.5px solid var(--color-border-strong);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-foreground-muted);
+    font-size: 14px;
+    z-index: 1;
+  }
+  .como__final {
+    position: absolute;
+    top: -10px;
+    right: 18px;
+    font-size: 22px;
+    color: var(--color-handwritten);
+    transform: rotate(-4deg);
+    background: var(--color-paper);
+    padding: 2px 10px;
+    border-radius: 999px;
+    border: 1px dashed var(--color-handwritten);
+  }
+</style>

--- a/src/components/mundial/EncuestaCampeon.tsx
+++ b/src/components/mundial/EncuestaCampeon.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import { SELECCIONES } from '@/lib/mundial/selecciones';
+import { SELECCIONES_DEL_TORNEO } from '@/lib/mundial/grupos';
+import type { Vote } from '@/lib/mundial/types';
+import { Flag } from './FlagPreact';
+
+/**
+ * Encuesta "¿quién crees que ganará el Mundial 2026?".
+ *
+ * Estado:
+ * - Cada usuario vota UNA vez (cambiable). Persistido en localStorage.
+ * - Los counts agregados son MOCK por ahora — distribución plausible que
+ *   favorece a las grandes potencias. Cuando exista backend (Fase 6),
+ *   sustituir `INITIAL_COUNTS` por un fetch a `/api/encuesta-campeon`.
+ * - El voto del usuario se suma client-side a los counts visibles para que
+ *   "su" voto se refleje en el podium inmediatamente.
+ *
+ * Vista A (sin voto): grid con las 48 selecciones, clic para elegir.
+ * Vista B (con voto): podium top 3 + ranking completo con barras + "cambiar voto".
+ */
+
+const LS_KEY = 'mg.mundial.encuesta-campeon';
+
+/**
+ * Mock de votos pre-cargados — escenario realista que el usuario verá la primera
+ * vez que entre. Total ~1200 votos. Distribución basada en favoritismo histórico
+ * + países anfitriones. Sustituir por fetch real en Fase 6.
+ */
+const INITIAL_COUNTS: Record<string, number> = {
+  ARG: 187, BRA: 152, FRA: 124, ESP: 118, ENG: 96, GER: 84, POR: 71, NED: 58,
+  MEX: 54, USA: 47, ITA: 42, URU: 38, COL: 35, BEL: 31, CRO: 28, JPN: 24,
+  MAR: 22, KOR: 19, CAN: 18, SUI: 16, DEN: 14, AUS: 13, SEN: 11, NOR: 10,
+  POL: 9,  AUT: 8,  ECU: 8,  TUR: 7, EGY: 7, NGA: 6, IRN: 6, KSA: 5,
+  PAR: 5,  CIV: 4,  GHA: 4,  ALG: 4, TUN: 3, CMR: 3, JAM: 3, QAT: 3,
+  CRC: 2,  PAN: 2,  HON: 2,  HUN: 2, SVK: 2, UZB: 1, NZL: 1, IRQ: 1,
+};
+
+function loadVote(): Vote | null {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Vote;
+    if (typeof parsed?.team !== 'string' || !SELECCIONES[parsed.team]) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function saveVote(v: Vote | null) {
+  try {
+    if (v) localStorage.setItem(LS_KEY, JSON.stringify(v));
+    else localStorage.removeItem(LS_KEY);
+  } catch {
+    // sin storage (navegador en modo privado): el voto solo dura la sesión.
+  }
+}
+
+export function EncuestaCampeon() {
+  const [voto, setVoto] = useState<Vote | null>(null);
+  const [hidratado, setHidratado] = useState(false);
+
+  // Cargar voto desde localStorage en mount (no en SSR — el componente es client-only).
+  useEffect(() => {
+    setVoto(loadVote());
+    setHidratado(true);
+  }, []);
+
+  function elegir(team: string) {
+    const v: Vote = { team, at: new Date().toISOString() };
+    setVoto(v);
+    saveVote(v);
+  }
+
+  function cambiar() {
+    setVoto(null);
+    saveVote(null);
+  }
+
+  // Counts agregados = mock + 1 al voto del usuario.
+  const counts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const code of SELECCIONES_DEL_TORNEO) {
+      c[code] = INITIAL_COUNTS[code] ?? 0;
+    }
+    if (voto) c[voto.team] = (c[voto.team] ?? 0) + 1;
+    return c;
+  }, [voto]);
+
+  const ranking = useMemo(() => {
+    return SELECCIONES_DEL_TORNEO
+      .map((code) => ({ code, votos: counts[code] ?? 0 }))
+      .sort((a, b) => b.votos - a.votos);
+  }, [counts]);
+
+  const total = useMemo(() => Object.values(counts).reduce((s, n) => s + n, 0), [counts]);
+
+  // Antes de hidratar evitamos parpadeo: render del skeleton (server-friendly).
+  if (!hidratado) {
+    return (
+      <div class="encuesta encuesta--loading" aria-busy="true">
+        <div class="encuesta__skeleton" />
+      </div>
+    );
+  }
+
+  if (!voto) return <SinVoto onElegir={elegir} />;
+  return <ConVoto voto={voto} ranking={ranking} total={total} onCambiar={cambiar} />;
+}
+
+// ───────────────────────────── Vista A: sin voto ─────────────────────────────
+
+function SinVoto({ onElegir }: { onElegir: (code: string) => void }) {
+  return (
+    <section class="encuesta encuesta--sin-voto" aria-labelledby="enc-titulo">
+      <header class="encuesta__header">
+        <span class="mono encuesta__eyebrow">06 · TU PRONÓSTICO</span>
+        <h2 id="enc-titulo" class="display encuesta__titulo">
+          ¿Quién crees que <span class="marker">ganará</span>?
+        </h2>
+        <p class="encuesta__intro">
+          Vota con tu peque. Pueden elegir entre las <strong>48 selecciones</strong>. Después verás el
+          podium de las más votadas por el resto de aficionados. <strong>Un voto por dispositivo</strong> —
+          puedes cambiarlo cuando quieras.
+        </p>
+      </header>
+
+      <ul class="encuesta__grid" role="list">
+        {SELECCIONES_DEL_TORNEO.map((code) => {
+          const t = SELECCIONES[code];
+          if (!t) return null;
+          return (
+            <li key={code}>
+              <button
+                type="button"
+                class="encuesta__opcion card-paper"
+                onClick={() => onElegir(code)}
+                aria-label={`Votar por ${t.nombre}`}
+              >
+                <Flag code={code} size={36} />
+                <span class="display encuesta__opcion-nombre">{t.nombre}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+// ───────────────────────────── Vista B: con voto ─────────────────────────────
+
+function ConVoto({
+  voto,
+  ranking,
+  total,
+  onCambiar,
+}: {
+  voto: Vote;
+  ranking: ReadonlyArray<{ code: string; votos: number }>;
+  total: number;
+  onCambiar: () => void;
+}) {
+  const elegido = SELECCIONES[voto.team];
+  const top3 = ranking.slice(0, 3);
+  const resto = ranking.slice(3);
+
+  // Para el podium: orden visual es [2°, 1°, 3°] de izquierda a derecha.
+  const podiumOrden = [top3[1], top3[0], top3[2]].filter(Boolean) as typeof top3;
+
+  return (
+    <section class="encuesta encuesta--con-voto" aria-labelledby="enc-titulo">
+      <header class="encuesta__header">
+        <span class="mono encuesta__eyebrow">06 · TU PRONÓSTICO</span>
+        <h2 id="enc-titulo" class="display encuesta__titulo">
+          Tu pronóstico: <span class="marker">{elegido?.nombre ?? voto.team}</span>
+        </h2>
+        <p class="encuesta__intro">
+          Has votado por <strong>{elegido?.nombre ?? voto.team}</strong>. Así va el podium de la
+          afición de MiniGol Club <span class="mono encuesta__total">({total.toLocaleString('es-ES')} votos)</span>.
+        </p>
+      </header>
+
+      <div class="encuesta__podium" aria-label="Podium de selecciones más votadas">
+        {podiumOrden.map((row) => {
+          if (!row) return null;
+          const t = SELECCIONES[row.code];
+          if (!t) return null;
+          const pos = ranking.findIndex((r) => r.code === row.code) + 1;
+          const pct = total > 0 ? Math.round((row.votos / total) * 100) : 0;
+          return (
+            <div
+              key={row.code}
+              class="encuesta__paso"
+              data-pos={pos}
+              data-mio={voto.team === row.code ? 'true' : 'false'}
+            >
+              <span class="display encuesta__paso-medalla" aria-hidden="true">{pos}°</span>
+              <div class="encuesta__paso-bandera">
+                <Flag code={row.code} size={pos === 1 ? 64 : 52} />
+              </div>
+              <span class="display encuesta__paso-nombre">{t.nombre}</span>
+              <span class="mono encuesta__paso-votos">{row.votos.toLocaleString('es-ES')} · {pct}%</span>
+              <div class="encuesta__paso-base" aria-hidden="true"></div>
+            </div>
+          );
+        })}
+      </div>
+
+      <details class="encuesta__detalles">
+        <summary class="mono encuesta__resumen">Ver ranking completo de las 48 selecciones</summary>
+        <ol class="encuesta__lista" role="list">
+          {resto.map((row, i) => {
+            const t = SELECCIONES[row.code];
+            if (!t) return null;
+            const pct = total > 0 ? Math.round((row.votos / total) * 100) : 0;
+            const pctBar = total > 0 ? (row.votos / (ranking[0]?.votos ?? 1)) * 100 : 0;
+            const esMio = voto.team === row.code;
+            return (
+              <li key={row.code} class="encuesta__row" data-mio={esMio ? 'true' : 'false'}>
+                <span class="mono encuesta__row-pos">{i + 4}</span>
+                <div class="encuesta__row-info">
+                  <Flag code={row.code} size={20} />
+                  <span class="display encuesta__row-nombre">{t.nombre}</span>
+                  {esMio && <span class="hand encuesta__row-mio">tú</span>}
+                </div>
+                <div class="encuesta__row-bar" aria-hidden="true">
+                  <span class="encuesta__row-bar-fill" style={{ width: `${pctBar}%` }}></span>
+                </div>
+                <span class="mono encuesta__row-pct">{pct}%</span>
+              </li>
+            );
+          })}
+        </ol>
+      </details>
+
+      <button type="button" class="btn btn-ghost encuesta__cambiar" onClick={onCambiar}>
+        Cambiar mi voto
+      </button>
+    </section>
+  );
+}
+
+export default EncuestaCampeon;

--- a/src/components/mundial/Flag.astro
+++ b/src/components/mundial/Flag.astro
@@ -1,0 +1,81 @@
+---
+import { getTeam } from '@/lib/mundial/selecciones';
+
+interface Props {
+  code: string;
+  size?: number;
+  rounded?: boolean;
+  /** Tamaño del texto del chip de fallback. Si no se pasa, se calcula. */
+  fallbackFontSize?: number;
+  class?: string;
+}
+
+const { code, size = 24, rounded = true, fallbackFontSize, class: className } = Astro.props;
+const team = getTeam(code);
+
+const width = size;
+const height = Math.round(size * 0.72);
+const radius = rounded ? Math.max(2, Math.round(size * 0.1)) : 0;
+const fallbackSize = fallbackFontSize ?? Math.max(8, Math.round(size * 0.32));
+
+const src = team ? `https://flagcdn.com/${team.iso2}.svg` : '';
+const alt = team?.nombre ?? code;
+const fallbackColor = team?.color ?? '#5a6172';
+---
+
+{team && (
+  <span
+    class:list={['flag', className]}
+    style={`--w:${width}px;--h:${height}px;--r:${radius}px;--fb-color:${fallbackColor};--fb-fs:${fallbackSize}px;`}
+  >
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      loading="lazy"
+      decoding="async"
+      onerror="this.classList.add('flag__img--failed')"
+    />
+    <span class="flag__fallback mono" aria-hidden="true">{code}</span>
+  </span>
+)}
+
+<style>
+  .flag {
+    position: relative;
+    display: inline-block;
+    width: var(--w);
+    height: var(--h);
+    flex-shrink: 0;
+    vertical-align: middle;
+  }
+  .flag img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: var(--r);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.15);
+  }
+  /* Fallback solo visible si la imagen falla (onerror añade la clase). */
+  .flag__fallback {
+    position: absolute;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: var(--fb-color);
+    color: #fff;
+    font-size: var(--fb-fs);
+    font-weight: 700;
+    border-radius: var(--r);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.15);
+  }
+  .flag img.flag__img--failed {
+    display: none;
+  }
+  .flag img.flag__img--failed + .flag__fallback {
+    display: flex;
+  }
+</style>

--- a/src/components/mundial/FlagPreact.tsx
+++ b/src/components/mundial/FlagPreact.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'preact/hooks';
+import { SELECCIONES } from '@/lib/mundial/selecciones';
+
+/**
+ * Versión Preact de <Flag/> para usar dentro de islas client-side.
+ * Mantiene el mismo contrato: img + fallback a chip de color si falla.
+ *
+ * El componente Astro de banderas (`Flag.astro`) no se puede importar dentro
+ * de archivos .tsx (Astro no expone los .astro como módulos JS al cliente).
+ * Por eso vive este gemelo en TSX. Mantener los dos en sync visualmente.
+ */
+
+interface Props {
+  code: string;
+  size?: number;
+  rounded?: boolean;
+  style?: Record<string, string | number>;
+}
+
+export function Flag({ code, size = 24, rounded = true, style }: Props) {
+  const team = SELECCIONES[code];
+  const [errored, setErrored] = useState(false);
+  if (!team) return null;
+
+  const w = size;
+  const h = Math.round(size * 0.72);
+  const radius = rounded ? Math.max(2, Math.round(size * 0.1)) : 0;
+
+  const common: Record<string, string | number> = {
+    display: 'inline-block',
+    verticalAlign: 'middle',
+    width: w,
+    height: h,
+    flexShrink: 0,
+    borderRadius: radius,
+    boxShadow: '0 0 0 1px rgba(0,0,0,.12), 0 1px 2px rgba(0,0,0,.15)',
+    ...(style ?? {}),
+  };
+
+  if (errored) {
+    return (
+      <span
+        style={{
+          ...common,
+          background: team.color,
+          color: '#fff',
+          fontFamily: 'var(--font-mono)',
+          fontSize: Math.max(8, Math.round(w * 0.32)),
+          fontWeight: 700,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        aria-label={team.nombre}
+      >
+        {code}
+      </span>
+    );
+  }
+
+  return (
+    <img
+      src={`https://flagcdn.com/${team.iso2}.svg`}
+      width={w}
+      height={h}
+      alt={team.nombre}
+      loading="lazy"
+      decoding="async"
+      onError={() => setErrored(true)}
+      style={{ ...common, objectFit: 'cover' }}
+    />
+  );
+}

--- a/src/components/mundial/Goleadores.astro
+++ b/src/components/mundial/Goleadores.astro
@@ -1,0 +1,142 @@
+---
+import type { Scorer } from '@/lib/mundial/types';
+import { getTeam } from '@/lib/mundial/selecciones';
+import Flag from './Flag.astro';
+
+interface Props {
+  goleadores: ReadonlyArray<Scorer>;
+  /** Cuántos mostrar (top N). Default 10. */
+  limit?: number;
+}
+
+const { goleadores, limit = 10 } = Astro.props;
+const top = goleadores.slice(0, limit);
+---
+
+<section class="goleadores card-paper" aria-label="Bota de oro del Mundial">
+  <header class="goleadores__header">
+    <span class="display goleadores__titulo">Bota de oro</span>
+    <span class="hand goleadores__sub">¿quién mete más goles?</span>
+  </header>
+
+  <ol class="goleadores__lista" role="list">
+    {top.map((g, i) => {
+      const team = getTeam(g.team);
+      const isPodium = i < 3;
+      const medalColor = i === 0 ? '#facc15' : i === 1 ? '#cbd5e1' : '#f97316';
+      return (
+        <li class="goleadores__item" data-podium={isPodium ? 'true' : 'false'}>
+          <span
+            class="display goleadores__pos"
+            style={isPodium ? `--podium-color:${medalColor};` : undefined}
+            aria-label={`Posición ${i + 1}`}
+          >
+            {String(i + 1).padStart(2, '0')}
+          </span>
+          <div class="goleadores__info">
+            <div class="goleadores__cabecera">
+              <Flag code={g.team} size={22} />
+              <span class="display goleadores__nombre">{g.player}</span>
+            </div>
+            <p class="hand goleadores__curio">{g.curiosidad}</p>
+            <span class="mono goleadores__pais">{team?.nombre ?? g.team}</span>
+          </div>
+          <div class="goleadores__goles">
+            <span class="display goleadores__cifra">{g.goles}</span>
+            <span class="mono goleadores__unidad">{g.goles === 1 ? 'GOL' : 'GOLES'}</span>
+          </div>
+        </li>
+      );
+    })}
+  </ol>
+</section>
+
+<style>
+  .goleadores {
+    padding: 0;
+    overflow: hidden;
+  }
+  .goleadores__header {
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface-alt);
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .goleadores__titulo {
+    font-size: 1.25rem;
+  }
+  .goleadores__sub {
+    font-size: 20px;
+    color: var(--color-handwritten);
+    transform: rotate(-2deg);
+    display: inline-block;
+  }
+  .goleadores__lista {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .goleadores__item {
+    display: grid;
+    grid-template-columns: 48px 1fr auto;
+    gap: 14px;
+    align-items: center;
+    padding: 14px 18px;
+    border-top: 1px solid var(--color-border);
+  }
+  .goleadores__item:first-child {
+    border-top: 0;
+  }
+  .goleadores__pos {
+    font-size: 1.5rem;
+    color: var(--color-foreground-subtle);
+    text-align: center;
+  }
+  .goleadores__item[data-podium='true'] .goleadores__pos {
+    color: var(--podium-color);
+  }
+  .goleadores__info {
+    min-width: 0;
+  }
+  .goleadores__cabecera {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .goleadores__nombre {
+    font-size: 1rem;
+  }
+  .goleadores__curio {
+    margin: 4px 0 2px;
+    font-size: 18px;
+    color: var(--color-handwritten);
+    line-height: 1.1;
+  }
+  .goleadores__pais {
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    color: var(--color-foreground-subtle);
+    text-transform: uppercase;
+  }
+  .goleadores__goles {
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+  .goleadores__cifra {
+    font-size: 1.75rem;
+    line-height: 1;
+    color: var(--color-secondary);
+  }
+  .goleadores__unidad {
+    font-size: 9px;
+    letter-spacing: 0.12em;
+    color: var(--color-foreground-subtle);
+    margin-top: 2px;
+  }
+</style>

--- a/src/components/mundial/GruposGrid.astro
+++ b/src/components/mundial/GruposGrid.astro
@@ -1,0 +1,145 @@
+---
+import { GRUPOS } from '@/lib/mundial/grupos';
+import { getTeam } from '@/lib/mundial/selecciones';
+import Flag from './Flag.astro';
+
+/**
+ * Los 12 grupos del Mundial 2026, con sus 4 selecciones cada uno.
+ * Pre-torneo: muestra solo banderas + nombres. Cuando empiece, la tabla
+ * de clasificación va en `TablaGrupo.astro` (componente separado).
+ */
+---
+
+<section class="grupos" aria-labelledby="grupos-titulo">
+  <div class="grupos__header">
+    <span class="mono grupos__eyebrow">03 · LAS 48 SELECCIONES</span>
+    <h2 id="grupos-titulo" class="display grupos__titulo">
+      Los <span class="marker">12 grupos</span> del Mundial
+    </h2>
+    <p class="grupos__intro">
+      Los 48 equipos se repartieron por sorteo en 12 grupos de 4. Cada grupo se identifica con una
+      letra de la <strong>A</strong> a la <strong>L</strong>. Estos son los rivales de cada selección:
+    </p>
+  </div>
+
+  <div class="grupos__grid">
+    {GRUPOS.map((g) => (
+      <article class="card-paper grupos__card" aria-labelledby={`grupo-${g.letra}-titulo`}>
+        <header class="grupos__card-header">
+          <span class="display grupos__letra" aria-hidden="true">{g.letra}</span>
+          <span id={`grupo-${g.letra}-titulo`} class="mono grupos__nombre">GRUPO {g.letra}</span>
+        </header>
+        <ul class="grupos__equipos" role="list">
+          {g.equipos.map((code) => {
+            const team = getTeam(code);
+            return (
+              <li class="grupos__equipo">
+                <Flag code={code} size={28} />
+                <span class="display grupos__equipo-nombre">{team?.nombre ?? code}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </article>
+    ))}
+  </div>
+
+  <p class="hand grupos__nota">
+    los <strong>2 primeros</strong> de cada grupo pasan a la siguiente fase, junto a los 8 mejores terceros.
+  </p>
+</section>
+
+<style>
+  .grupos {
+    margin-top: 56px;
+  }
+  .grupos__header {
+    max-width: 60ch;
+    margin-bottom: 24px;
+  }
+  .grupos__eyebrow {
+    display: inline-block;
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    color: var(--color-foreground-subtle);
+    margin-bottom: 8px;
+  }
+  .grupos__titulo {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    margin: 0 0 14px;
+  }
+  .grupos__intro {
+    color: var(--color-foreground-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    margin: 0;
+  }
+  .grupos__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+    margin-top: 22px;
+  }
+  .grupos__card {
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .grupos__card-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding-bottom: 10px;
+    border-bottom: 1px dashed var(--color-border);
+  }
+  .grupos__letra {
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    line-height: 1;
+    color: var(--color-energy);
+  }
+  .grupos__nombre {
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    color: var(--color-foreground-subtle);
+  }
+  .grupos__equipos {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 10px;
+  }
+  .grupos__equipo {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .grupos__equipo-nombre {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--color-foreground);
+  }
+  .grupos__nota {
+    margin-top: 22px;
+    font-size: 22px;
+    color: var(--color-handwritten);
+    text-align: center;
+    transform: rotate(-1deg);
+  }
+  .grupos__nota strong {
+    background-image: linear-gradient(180deg, transparent 60%, var(--color-marker) 60%, var(--color-marker) 92%, transparent 92%);
+    padding: 0 0.1em;
+  }
+
+  @media (min-width: 640px) {
+    .grupos__grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  @media (min-width: 1024px) {
+    .grupos__grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+</style>

--- a/src/components/mundial/HistoriaCuriosa.astro
+++ b/src/components/mundial/HistoriaCuriosa.astro
@@ -1,0 +1,203 @@
+---
+import Flag from './Flag.astro';
+
+/**
+ * Sección de historia + datos curiosos del Mundial.
+ * - Lista de últimos 5 campeones (más memorables para padres y peques).
+ * - 4-5 datos curiosos con microcopy manuscrito.
+ *
+ * Pensado para ser narrativo: el padre lo lee con el peque al lado.
+ */
+
+const campeones = [
+  { ano: '2022', sede: 'Catar',                    campeon: 'ARG', curiosidad: 'Messi por fin la levantó. Tercer Mundial para Argentina.' },
+  { ano: '2018', sede: 'Rusia',                    campeon: 'FRA', curiosidad: 'Mbappé tenía 19 años y ya era campeón del mundo.' },
+  { ano: '2014', sede: 'Brasil',                   campeon: 'GER', curiosidad: 'Le ganaron 7-1 a Brasil en su propia casa. Histórico.' },
+  { ano: '2010', sede: 'Sudáfrica',                campeon: 'ESP', curiosidad: 'Primer Mundial de España. Iniesta marcó en la final.' },
+  { ano: '2006', sede: 'Alemania',                 campeon: 'ITA', curiosidad: 'Italia ganó por penales. Cabezazo legendario de Zidane.' },
+];
+
+const curiosidades = [
+  {
+    titulo: '¿Sabías que…?',
+    texto: 'El Mundial se juega cada 4 años desde 1930. Solo se paró dos veces, durante la Segunda Guerra Mundial.',
+  },
+  {
+    titulo: 'Brasil mandona',
+    texto: 'Brasil es la selección que más mundiales ha ganado: 5. El último fue en 2002.',
+  },
+  {
+    titulo: 'El más grande',
+    texto: 'El Mundial 2026 es el primero con 48 selecciones. El de 1930 solo tuvo 13.',
+  },
+  {
+    titulo: 'Estadios para 80.000 personas',
+    texto: 'La final se juega en el estadio MetLife de Nueva Jersey. Caben más de 80.000 aficionados.',
+  },
+  {
+    titulo: 'La mascota oficial',
+    texto: 'El Mundial 2026 tiene tres mascotas: Maple (alce canadiense), Zayu (jaguar mexicano) y Clutch (águila americana).',
+  },
+];
+---
+
+<section class="hist" aria-labelledby="hist-titulo">
+  <div class="hist__header">
+    <span class="mono hist__eyebrow">05 · UN POCO DE HISTORIA</span>
+    <h2 id="hist-titulo" class="display hist__titulo">
+      Los últimos <span class="marker">campeones del mundo</span>
+    </h2>
+    <p class="hist__intro">
+      Solo 8 países han ganado un Mundial en toda la historia. Estos son los últimos 5 que
+      levantaron la copa.
+    </p>
+  </div>
+
+  <ul class="hist__campeones" role="list">
+    {campeones.map((c) => (
+      <li class="card-paper hist__campeon">
+        <div class="hist__campeon-top">
+          <span class="display hist__ano">{c.ano}</span>
+          <span class="mono hist__sede">{c.sede.toUpperCase()}</span>
+        </div>
+        <div class="hist__campeon-info">
+          <Flag code={c.campeon} size={48} />
+          <p class="hist__campeon-texto">{c.curiosidad}</p>
+        </div>
+      </li>
+    ))}
+  </ul>
+
+  <div class="hist__curio">
+    <h3 class="display hist__curio-titulo">
+      Datos <span class="hand hist__curio-acento">¡súper curiosos!</span>
+    </h3>
+    <div class="hist__curio-grid">
+      {curiosidades.map((c) => (
+        <article class="card-paper hist__curio-card">
+          <h4 class="display hist__curio-card-titulo">{c.titulo}</h4>
+          <p class="hist__curio-texto">{c.texto}</p>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>
+
+<style>
+  .hist {
+    margin-top: 56px;
+  }
+  .hist__header {
+    max-width: 60ch;
+    margin-bottom: 24px;
+  }
+  .hist__eyebrow {
+    display: inline-block;
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    color: var(--color-foreground-subtle);
+    margin-bottom: 8px;
+  }
+  .hist__titulo {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    margin: 0 0 14px;
+  }
+  .hist__intro {
+    color: var(--color-foreground-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    margin: 0;
+  }
+
+  .hist__campeones {
+    list-style: none;
+    padding: 0;
+    margin: 22px 0 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .hist__campeon {
+    padding: 16px 18px;
+    display: grid;
+    gap: 12px;
+  }
+  .hist__campeon-top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding-bottom: 8px;
+    border-bottom: 1px dashed var(--color-border);
+  }
+  .hist__ano {
+    font-size: 1.75rem;
+    line-height: 1;
+    color: var(--color-energy);
+  }
+  .hist__sede {
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    color: var(--color-foreground-subtle);
+  }
+  .hist__campeon-info {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+  .hist__campeon-texto {
+    margin: 0;
+    color: var(--color-foreground-muted);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
+  .hist__curio {
+    margin-top: 40px;
+  }
+  .hist__curio-titulo {
+    font-size: clamp(1.5rem, 3.5vw, 2rem);
+    margin: 0 0 18px;
+  }
+  .hist__curio-acento {
+    font-size: 1.4em;
+    color: var(--color-handwritten);
+    display: inline-block;
+    transform: rotate(-2deg);
+  }
+  .hist__curio-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .hist__curio-card {
+    padding: 16px 18px;
+  }
+  .hist__curio-card-titulo {
+    font-size: 1.05rem;
+    margin: 0 0 6px;
+    color: var(--color-foreground);
+  }
+  .hist__curio-texto {
+    margin: 0;
+    color: var(--color-foreground-muted);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
+  @media (min-width: 640px) {
+    .hist__campeones {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .hist__curio-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  @media (min-width: 1024px) {
+    .hist__campeones {
+      grid-template-columns: repeat(5, 1fr);
+    }
+    .hist__curio-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+</style>

--- a/src/components/mundial/PartidoRow.astro
+++ b/src/components/mundial/PartidoRow.astro
@@ -1,0 +1,123 @@
+---
+import type { Match } from '@/lib/mundial/types';
+import { getTeam } from '@/lib/mundial/selecciones';
+import { fmtCountdown, fmtTime } from '@/lib/mundial/format';
+import Flag from './Flag.astro';
+
+interface Props {
+  partido: Match;
+}
+
+const { partido: p } = Astro.props;
+const home = getTeam(p.home);
+const away = getTeam(p.away);
+const isLive = p.status === 'live';
+const isFin = p.status === 'finished';
+
+const countdown = !isLive && !isFin ? (fmtCountdown(p.kickoff) ?? fmtTime(p.kickoff)) : null;
+---
+
+<article
+  class="partido card-paper"
+  data-status={p.status}
+  aria-label={`${home?.nombre ?? p.home} contra ${away?.nombre ?? p.away}`}
+>
+  <div class="partido__lado partido__lado--home">
+    <Flag code={p.home} size={28} />
+    <span class="display partido__nombre">{home?.nombre ?? p.home}</span>
+  </div>
+
+  <div class="partido__centro">
+    {p.homeScore !== null && p.awayScore !== null ? (
+      <div class="display partido__marcador" data-live={isLive ? 'true' : 'false'}>
+        {p.homeScore}<span class="partido__sep" aria-hidden="true">·</span>{p.awayScore}
+      </div>
+    ) : (
+      <div class="mono partido__countdown">{countdown}</div>
+    )}
+    <div class="mono partido__estado">
+      {isLive && <><span class="partido__live-dot" aria-hidden="true"></span>{p.minute}'</>}
+      {isFin && 'FINAL'}
+      {!isLive && !isFin && p.fase}
+    </div>
+  </div>
+
+  <div class="partido__lado partido__lado--away">
+    <span class="display partido__nombre">{away?.nombre ?? p.away}</span>
+    <Flag code={p.away} size={28} />
+  </div>
+</article>
+
+<style>
+  .partido {
+    padding: 14px 16px;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 12px;
+    align-items: center;
+  }
+  .partido__lado {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .partido__lado--home {
+    justify-content: flex-end;
+  }
+  .partido__nombre {
+    font-size: 0.95rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .partido__centro {
+    min-width: 80px;
+    text-align: center;
+  }
+  .partido__marcador {
+    font-size: 1.5rem;
+    line-height: 1;
+    color: var(--color-foreground);
+  }
+  .partido__marcador[data-live='true'] {
+    color: var(--color-energy);
+  }
+  .partido__sep {
+    color: var(--color-foreground-subtle);
+    margin: 0 6px;
+  }
+  .partido__countdown {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+  .partido__estado {
+    font-size: 9px;
+    color: var(--color-foreground-subtle);
+    letter-spacing: 0.08em;
+    margin-top: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+  }
+  .partido[data-status='live'] .partido__estado {
+    color: var(--color-energy);
+  }
+  .partido__live-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--color-energy);
+    animation: partido-pulse 1.4s infinite;
+  }
+  @keyframes partido-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.35; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .partido__live-dot { animation: none; }
+  }
+</style>

--- a/src/components/mundial/QueEsElMundial.astro
+++ b/src/components/mundial/QueEsElMundial.astro
@@ -1,0 +1,155 @@
+---
+import { Icon } from 'astro-icon/components';
+
+/**
+ * Sección explicativa "¿qué es el Mundial?" para 4-12 años.
+ * Tres cards con datos esenciales + microcopy manuscrito.
+ * Lenguaje sencillo: nada de "FIFA", "ranking", "draw" — esos van en HistoriaCuriosa.
+ */
+
+const cards = [
+  {
+    icon: 'lucide:trophy',
+    titulo: '48 selecciones',
+    dato: '48',
+    unidad: 'países',
+    explicacion: 'Es la primera vez en la historia que juegan tantos. Antes eran 32. Ahora ¡16 más!',
+    manuscrito: '¡más equipos que nunca!',
+  },
+  {
+    icon: 'lucide:calendar-days',
+    titulo: 'Una vez cada 4 años',
+    dato: '4',
+    unidad: 'años',
+    explicacion: 'El Mundial solo pasa cada 4 años. El anterior fue en Catar 2022. El próximo, en 2030.',
+    manuscrito: 'la espera vale la pena',
+  },
+  {
+    icon: 'lucide:globe',
+    titulo: 'Tres países anfitriones',
+    dato: '3',
+    unidad: 'países',
+    explicacion: 'Se juega en Estados Unidos, México y Canadá. En 16 ciudades distintas, ¡todo a la vez!',
+    manuscrito: 'tres países, un mundial',
+  },
+];
+---
+
+<section class="que-es" aria-labelledby="que-es-titulo">
+  <div class="que-es__header">
+    <span class="mono que-es__eyebrow">01 · LO BÁSICO</span>
+    <h2 id="que-es-titulo" class="display que-es__titulo">
+      ¿Qué es <span class="marker">el Mundial</span>?
+    </h2>
+    <p class="que-es__intro">
+      El Mundial de fútbol es el torneo más importante del planeta. Cada cuatro años, los mejores
+      equipos de cada país juegan para ver quién es <strong>el campeón del mundo</strong>. Este año
+      hay algo nuevo y muy especial.
+    </p>
+  </div>
+
+  <div class="que-es__grid">
+    {cards.map((c) => (
+      <article class="card-paper que-es__card">
+        <div class="que-es__icon" aria-hidden="true">
+          <Icon name={c.icon} class="h-5 w-5" />
+        </div>
+        <div class="mono que-es__label">{c.titulo}</div>
+        <div class="display que-es__dato">
+          {c.dato}<span class="que-es__unidad">{c.unidad}</span>
+        </div>
+        <p class="que-es__explicacion">{c.explicacion}</p>
+        <p class="hand que-es__manuscrito">{c.manuscrito}</p>
+      </article>
+    ))}
+  </div>
+</section>
+
+<style>
+  .que-es {
+    margin-top: 48px;
+  }
+  .que-es__header {
+    max-width: 60ch;
+    margin-bottom: 24px;
+  }
+  .que-es__eyebrow {
+    display: inline-block;
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    color: var(--color-foreground-subtle);
+    margin-bottom: 8px;
+  }
+  .que-es__titulo {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    margin: 0 0 14px;
+    line-height: 1.05;
+  }
+  .que-es__intro {
+    color: var(--color-foreground-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    margin: 0;
+  }
+  .que-es__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 14px;
+    margin-top: 22px;
+  }
+  .que-es__card {
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .que-es__icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
+    background: var(--color-surface-alt);
+    color: var(--color-energy);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 4px;
+  }
+  .que-es__label {
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    color: var(--color-foreground-subtle);
+    text-transform: uppercase;
+  }
+  .que-es__dato {
+    font-size: clamp(2.5rem, 6vw, 3.5rem);
+    line-height: 0.9;
+    color: var(--color-energy);
+    margin-top: 2px;
+  }
+  .que-es__unidad {
+    font-size: 0.4em;
+    color: var(--color-foreground-muted);
+    margin-left: 0.3em;
+    letter-spacing: 0;
+  }
+  .que-es__explicacion {
+    color: var(--color-foreground-muted);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    margin: 8px 0 0;
+  }
+  .que-es__manuscrito {
+    font-size: 20px;
+    color: var(--color-handwritten);
+    margin: 0;
+    transform: rotate(-2deg);
+    transform-origin: left center;
+    align-self: flex-start;
+  }
+
+  @media (min-width: 640px) {
+    .que-es__grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+</style>

--- a/src/components/mundial/TablaGrupo.astro
+++ b/src/components/mundial/TablaGrupo.astro
@@ -1,0 +1,162 @@
+---
+import type { Standing } from '@/lib/mundial/types';
+import { getTeam } from '@/lib/mundial/selecciones';
+import Flag from './Flag.astro';
+
+interface Props {
+  letra: string;
+  tabla: ReadonlyArray<Standing>;
+  /** Jornada actual / total. Si no hay partidos jugados todavía, usar `0/3`. */
+  jornada?: { actual: number; total: number };
+}
+
+const { letra, tabla, jornada = { actual: 0, total: 3 } } = Astro.props;
+const sinJugar = tabla.every((s) => s.pj === 0);
+---
+
+<div class="tabla card-paper" aria-label={`Tabla del Grupo ${letra}`}>
+  <header class="tabla__header">
+    <span class="display tabla__titulo">Grupo {letra}</span>
+    <span class="mono tabla__jornada">JORNADA {jornada.actual}/{jornada.total}</span>
+  </header>
+
+  <table class="tabla__tabla">
+    <thead>
+      <tr>
+        <th scope="col" class="mono tabla__th tabla__th--num">#</th>
+        <th scope="col" class="mono tabla__th tabla__th--equipo">Equipo</th>
+        <th scope="col" class="mono tabla__th">PJ</th>
+        <th scope="col" class="mono tabla__th">G</th>
+        <th scope="col" class="mono tabla__th">E</th>
+        <th scope="col" class="mono tabla__th">P</th>
+        <th scope="col" class="mono tabla__th">GF</th>
+        <th scope="col" class="mono tabla__th">GC</th>
+        <th scope="col" class="mono tabla__th tabla__th--pts">PTS</th>
+      </tr>
+    </thead>
+    <tbody>
+      {tabla.map((row, i) => {
+        const t = getTeam(row.team);
+        const clasifica = i < 2;
+        return (
+          <tr data-clasifica={clasifica ? 'true' : 'false'}>
+            <td class="mono tabla__td tabla__td--num">{i + 1}</td>
+            <td class="tabla__td tabla__td--equipo">
+              <Flag code={row.team} size={22} />
+              <span class="display tabla__nombre">{t?.nombre ?? row.team}</span>
+            </td>
+            <td class="mono tabla__td">{sinJugar ? '–' : row.pj}</td>
+            <td class="mono tabla__td tabla__td--g">{sinJugar ? '–' : row.g}</td>
+            <td class="mono tabla__td">{sinJugar ? '–' : row.e}</td>
+            <td class="mono tabla__td tabla__td--p">{sinJugar ? '–' : row.p}</td>
+            <td class="mono tabla__td">{sinJugar ? '–' : row.gf}</td>
+            <td class="mono tabla__td tabla__td--gc">{sinJugar ? '–' : row.gc}</td>
+            <td class="display tabla__td tabla__td--pts">{sinJugar ? '–' : row.pts}</td>
+          </tr>
+        );
+      })}
+    </tbody>
+  </table>
+
+  <p class="mono tabla__leyenda">
+    <span class="tabla__leyenda-dot" aria-hidden="true"></span>
+    primeros 2 clasifican
+  </p>
+</div>
+
+<style>
+  .tabla {
+    padding: 0;
+    overflow: hidden;
+  }
+  .tabla__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface-alt);
+  }
+  .tabla__titulo {
+    font-size: 1.1rem;
+  }
+  .tabla__jornada {
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    color: var(--color-foreground-subtle);
+  }
+  .tabla__tabla {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  .tabla__th {
+    padding: 8px 6px;
+    text-align: center;
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    color: var(--color-foreground-subtle);
+    font-weight: 600;
+  }
+  .tabla__th--equipo {
+    text-align: left;
+    padding-left: 10px;
+  }
+  .tabla__th--pts,
+  .tabla__th--num {
+    background: color-mix(in oklab, var(--color-surface-alt), transparent 50%);
+  }
+  .tabla__td {
+    padding: 9px 6px;
+    text-align: center;
+    font-size: 12px;
+    border-top: 1px solid var(--color-border);
+  }
+  .tabla__td--equipo {
+    text-align: left;
+    padding-left: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .tabla__nombre {
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+  .tabla__td--num {
+    color: var(--color-foreground-subtle);
+    font-weight: 700;
+  }
+  tr[data-clasifica='true'] .tabla__td--num {
+    color: var(--color-secondary);
+  }
+  .tabla__td--g {
+    color: var(--color-secondary);
+  }
+  .tabla__td--p {
+    color: var(--color-energy);
+  }
+  .tabla__td--gc {
+    color: var(--color-foreground-subtle);
+  }
+  .tabla__td--pts {
+    font-size: 0.95rem;
+    font-weight: 700;
+  }
+  .tabla__leyenda {
+    padding: 8px 16px;
+    font-size: 9px;
+    color: var(--color-foreground-subtle);
+    border-top: 1px solid var(--color-border);
+    background: var(--color-paper);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .tabla__leyenda-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: var(--color-secondary);
+  }
+</style>

--- a/src/components/mundial/TickerBolsa.tsx
+++ b/src/components/mundial/TickerBolsa.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'preact/hooks';
+import { memo } from 'preact/compat';
+import type { Match } from '@/lib/mundial/types';
+import { SELECCIONES } from '@/lib/mundial/selecciones';
+import { fmtCountdown, fmtTime } from '@/lib/mundial/format';
+import { Flag } from './FlagPreact';
+
+/**
+ * Ticker estilo "bolsa de valores" — barra superior negra con scroll horizontal
+ * continuo (CSS animation 60s linear infinite). Reconocible para padres.
+ *
+ * Diseñado para ser puesto encima del Header global durante el torneo. NO se
+ * mueve por JS (CSS animation es más eficiente y no compite con scroll del
+ * usuario). Pausa cuando el usuario tiene `prefers-reduced-motion: reduce`.
+ *
+ * `memo` para que un cambio de `minute` en un partido individual no fuerce
+ * re-render del DOM completo (el ticker dibuja 16 elementos × 2 duplicados).
+ */
+
+interface Props {
+  partidos: ReadonlyArray<Match>;
+  dismissable?: boolean;
+}
+
+function TickerBolsaImpl({ partidos, dismissable = true }: Props) {
+  const [dismissed, setDismissed] = useState(false);
+  if (dismissed || partidos.length === 0) return null;
+
+  const items = [...partidos, ...partidos];
+  const anyLive = partidos.some((p) => p.status === 'live');
+
+  return (
+    <div class="tickerb" aria-live={anyLive ? 'polite' : 'off'} aria-label="Marcador del Mundial en vivo">
+      <div class="tickerb__inner">
+        <div class="tickerb__pill" aria-hidden="true">
+          <span class="tickerb__dot"></span>
+          <span class="tickerb__pill-text">MUNDIAL 26 · EN VIVO</span>
+        </div>
+
+        <div class="tickerb__track">
+          <div class="tickerb__scroller">
+            {items.map((p, i) => {
+              const home = SELECCIONES[p.home];
+              const away = SELECCIONES[p.away];
+              if (!home || !away) return null;
+              const isLive = p.status === 'live';
+              const isFinished = p.status === 'finished';
+              return (
+                <span class="tickerb__item" key={`${p.id}-${i}`}>
+                  {isLive && <span class="tickerb__dot tickerb__dot--green" aria-hidden="true"></span>}
+                  <Flag code={p.home} size={20} />
+                  <span class="tickerb__code">{p.home}</span>
+                  <span class={isLive ? 'tickerb__score tickerb__score--live' : 'tickerb__score'}>
+                    {p.homeScore ?? '–'} : {p.awayScore ?? '–'}
+                  </span>
+                  <span class="tickerb__code">{p.away}</span>
+                  <Flag code={p.away} size={20} />
+                  {isLive && <span class="tickerb__minute">{p.minute}'</span>}
+                  {isFinished && <span class="tickerb__fin">FIN</span>}
+                  {p.status === 'scheduled' && (
+                    <span class="tickerb__countdown">
+                      {fmtCountdown(p.kickoff) ?? fmtTime(p.kickoff)}
+                    </span>
+                  )}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+
+        {dismissable && (
+          <button
+            type="button"
+            class="tickerb__close"
+            onClick={() => setDismissed(true)}
+            aria-label="Cerrar barra del marcador"
+          >
+            ×
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const TickerBolsa = memo(TickerBolsaImpl);
+export default TickerBolsa;

--- a/src/components/mundial/TickerCuaderno.astro
+++ b/src/components/mundial/TickerCuaderno.astro
@@ -1,0 +1,140 @@
+---
+import type { Match } from '@/lib/mundial/types';
+import { fmtCountdown, fmtTime } from '@/lib/mundial/format';
+import Flag from './Flag.astro';
+
+interface Props {
+  partidos: ReadonlyArray<Match>;
+  /** Cuántos partidos mostrar. Default 4. */
+  limit?: number;
+  /** Fecha humana del banner ("11 jun 26"). Si no, se omite. */
+  fecha?: string;
+}
+
+const { partidos, limit = 4, fecha } = Astro.props;
+const top = partidos.slice(0, limit);
+---
+
+<div class="cuaderno" aria-label="Marcador del día">
+  <header class="cuaderno__header">
+    <span class="hand cuaderno__titulo">marcador del día</span>
+    <span class="cuaderno__sep" aria-hidden="true"></span>
+    {fecha && <span class="mono cuaderno__fecha">MUNDIAL · {fecha}</span>}
+  </header>
+
+  <ul class="cuaderno__lista" role="list">
+    {top.map((p) => {
+      const isLive = p.status === 'live';
+      const isFin = p.status === 'finished';
+      const tieneMarcador = p.homeScore !== null && p.awayScore !== null;
+      return (
+        <li class="cuaderno__fila" data-live={isLive ? 'true' : 'false'}>
+          <div class="cuaderno__lado cuaderno__lado--home">
+            <span class="mono cuaderno__codigo">{p.home}</span>
+            <Flag code={p.home} size={22} />
+          </div>
+          <div class="cuaderno__centro">
+            {tieneMarcador ? (
+              <span class="hand cuaderno__marcador">{p.homeScore} - {p.awayScore}</span>
+            ) : (
+              <span class="mono cuaderno__hora">{fmtCountdown(p.kickoff) ?? fmtTime(p.kickoff)}</span>
+            )}
+            {isLive && <span class="mono cuaderno__estado cuaderno__estado--live">● {p.minute}'</span>}
+            {isFin && <span class="mono cuaderno__estado">FINAL</span>}
+          </div>
+          <div class="cuaderno__lado">
+            <Flag code={p.away} size={22} />
+            <span class="mono cuaderno__codigo">{p.away}</span>
+          </div>
+        </li>
+      );
+    })}
+  </ul>
+</div>
+
+<style>
+  .cuaderno {
+    background: var(--color-foreground);
+    color: #fffcf1;
+    border-radius: var(--radius-lg);
+    padding: 18px 22px;
+    position: relative;
+    overflow: hidden;
+  }
+  .cuaderno__header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+  .cuaderno__titulo {
+    font-size: 1.4rem;
+    color: var(--color-marker);
+  }
+  .cuaderno__sep {
+    flex: 1;
+    height: 1px;
+    border-top: 1px dashed rgba(255, 252, 241, 0.2);
+  }
+  .cuaderno__fecha {
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    opacity: 0.6;
+  }
+  .cuaderno__lista {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 8px;
+  }
+  .cuaderno__fila {
+    display: grid;
+    grid-template-columns: 1fr 90px 1fr;
+    gap: 12px;
+    align-items: center;
+    padding: 6px 10px;
+    border-radius: 6px;
+  }
+  .cuaderno__fila[data-live='true'] {
+    background: rgba(220, 38, 38, 0.15);
+  }
+  .cuaderno__lado {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .cuaderno__lado--home {
+    justify-content: flex-end;
+  }
+  .cuaderno__codigo {
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .cuaderno__centro {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+  }
+  .cuaderno__marcador {
+    font-size: 1.5rem;
+    color: var(--color-marker);
+    line-height: 1;
+  }
+  .cuaderno__hora {
+    font-size: 11px;
+    color: var(--color-marker);
+    opacity: 0.85;
+  }
+  .cuaderno__estado {
+    font-size: 8px;
+    letter-spacing: 0.1em;
+    opacity: 0.5;
+  }
+  .cuaderno__estado--live {
+    color: #4ade80;
+    opacity: 1;
+  }
+</style>

--- a/src/components/mundial/TickerSlide.tsx
+++ b/src/components/mundial/TickerSlide.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'preact/hooks';
+import type { Match } from '@/lib/mundial/types';
+import { SELECCIONES } from '@/lib/mundial/selecciones';
+import { fmtCountdown, fmtTime } from '@/lib/mundial/format';
+import { Flag } from './FlagPreact';
+
+/**
+ * Card autoplay con dots (4.5s entre slides) para destacar 1 o más partidos
+ * "en vivo" en la home/sidebar. Banderas grandes (68px) + marcador display 38px.
+ *
+ * Si `prefers-reduced-motion: reduce`, no autoplay — el usuario navega con dots.
+ * Si solo hay 1 partido, no aparecen dots.
+ */
+
+interface Props {
+  partidos: ReadonlyArray<Match>;
+  intervalMs?: number;
+}
+
+export function TickerSlide({ partidos, intervalMs = 4500 }: Props) {
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    if (partidos.length < 2) return;
+    if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+    const t = setInterval(() => setIdx((i) => (i + 1) % partidos.length), intervalMs);
+    return () => clearInterval(t);
+  }, [partidos.length, intervalMs]);
+
+  if (partidos.length === 0) return null;
+  const p = partidos[Math.min(idx, partidos.length - 1)];
+  if (!p) return null;
+  const home = SELECCIONES[p.home];
+  const away = SELECCIONES[p.away];
+  if (!home || !away) return null;
+  const isLive = p.status === 'live';
+  const isFin = p.status === 'finished';
+
+  return (
+    <article class="tickers card-paper" aria-live={isLive ? 'polite' : 'off'}>
+      <header class="tickers__header">
+        {isLive ? (
+          <span class="tickers__live mono">
+            <span class="tickers__live-dot" aria-hidden="true"></span>
+            EN VIVO
+          </span>
+        ) : (
+          <span class="tickers__fase mono">{p.fase.toUpperCase()}</span>
+        )}
+        {p.grupo && <span class="tickers__grupo mono">GRUPO {p.grupo}</span>}
+      </header>
+
+      <div class="tickers__partido">
+        <div class="tickers__lado">
+          <Flag code={p.home} size={68} rounded={true} style={{ borderRadius: '8px' }} />
+          <div class="tickers__nombre display">{home.nombre}</div>
+        </div>
+        <div class="tickers__centro">
+          {p.homeScore !== null && p.awayScore !== null ? (
+            <div class={isLive ? 'tickers__score tickers__score--live display' : 'tickers__score display'}>
+              {p.homeScore}<span class="tickers__sep">:</span>{p.awayScore}
+            </div>
+          ) : (
+            <div class="tickers__vs display">vs</div>
+          )}
+          <div class="tickers__estado mono">
+            {isLive ? `${p.minute}'` : isFin ? 'FINAL' : (fmtCountdown(p.kickoff) ?? fmtTime(p.kickoff))}
+          </div>
+        </div>
+        <div class="tickers__lado">
+          <Flag code={p.away} size={68} rounded={true} style={{ borderRadius: '8px' }} />
+          <div class="tickers__nombre display">{away.nombre}</div>
+        </div>
+      </div>
+
+      {partidos.length > 1 && (
+        <nav class="tickers__dots" aria-label="Cambiar partido">
+          {partidos.map((mp, i) => (
+            <button
+              type="button"
+              key={mp.id}
+              class={i === idx ? 'tickers__dot tickers__dot--active' : 'tickers__dot'}
+              onClick={() => setIdx(i)}
+              aria-label={`Ir al partido ${i + 1} de ${partidos.length}`}
+              aria-current={i === idx ? 'true' : 'false'}
+            />
+          ))}
+        </nav>
+      )}
+    </article>
+  );
+}
+
+export default TickerSlide;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -31,11 +31,18 @@ export const AUTHOR = {
   email: 'hola@minigolclub.com',
 } as const;
 
+/**
+ * Navegación principal. `featured: true` renderiza un punto rojo a la
+ * derecha del enlace — usado para destacar contenido temporal de alta
+ * relevancia (ej. Mundial mientras está caliente). Tras el 21-jul-2026
+ * (post-final), quitar la entrada de Mundial o el flag `featured`.
+ */
 export const NAV_PRIMARY = [
   { label: 'Ejercicios', href: '/ejercicios/' },
   { label: 'Juegos', href: '/juegos/' },
   { label: 'Equipamiento', href: '/equipamiento/' },
   { label: 'Iniciación', href: '/iniciacion/' },
+  { label: 'Mundial 26', href: '/mundial-2026/', featured: true },
   { label: 'Recursos', href: '/recursos/' },
 ] as const;
 

--- a/src/i18n/ca.ts
+++ b/src/i18n/ca.ts
@@ -18,6 +18,7 @@ export const ca = {
   'nav-juegos': 'Jocs',
   'nav-equipamiento': 'Equipament',
   'nav-iniciacion': 'Iniciació',
+  'nav-mundial': 'Mundial 26',
   'nav-recursos': 'Recursos',
   'nav-aria-primary': 'Navegació principal',
   'nav-aria-mobile-menu': 'Menú de navegació',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -18,6 +18,7 @@ export const es = {
   'nav-juegos': 'Juegos',
   'nav-equipamiento': 'Equipamiento',
   'nav-iniciacion': 'Iniciación',
+  'nav-mundial': 'Mundial 26',
   'nav-recursos': 'Recursos',
   'nav-aria-primary': 'Navegación principal',
   'nav-aria-mobile-menu': 'Menú de navegación',

--- a/src/lib/mundial/dates.ts
+++ b/src/lib/mundial/dates.ts
@@ -1,0 +1,113 @@
+/**
+ * Fechas y banderas temporales del Mundial 2026. Centralizadas para que
+ * cualquier componente / endpoint decida si renderizar la cara "previa"
+ * (educativa) o la cara "live" (resultados) sin acoplarse a fechas duras.
+ *
+ * Si el día de mañana hay un Mundial femenino 2027, se duplica este
+ * archivo a `dates-fem-2027.ts` y los componentes reciben el objeto
+ * `Tournament` por prop. NO hay fechas hardcoded fuera de este módulo.
+ */
+
+export type Tournament = {
+  slug: string;
+  nombre: string;
+  edicion: string;
+  /** Inauguración (kickoff del primer partido) — ISO UTC. */
+  inauguracion: Date;
+  /** Final — ISO UTC. */
+  final: Date;
+  /** Cuándo enciende el "modo live" en la página (días antes de la inauguración). */
+  previaDias: number;
+  /** Cuándo apaga el "modo live" (días después de la final). */
+  postFinalDias: number;
+  /** Hitos editoriales del torneo, en orden cronológico. */
+  hitos: ReadonlyArray<{
+    fecha: Date;
+    nombre: string;
+    /** Microcopy manuscrito para niños. */
+    descripcion: string;
+  }>;
+};
+
+/**
+ * Constantes del Mundial 2026 (Canadá · México · Estados Unidos).
+ * Fuente: calendario oficial FIFA. Inauguración 11 jun, final 19 jul.
+ */
+export const MUNDIAL_2026: Tournament = {
+  slug: 'mundial-2026',
+  nombre: 'Mundial',
+  edicion: '2026',
+  inauguracion: new Date('2026-06-11T20:00:00Z'),
+  final: new Date('2026-07-19T19:00:00Z'),
+  previaDias: 7,
+  postFinalDias: 2,
+  hitos: [
+    {
+      fecha: new Date('2026-06-11T20:00:00Z'),
+      nombre: 'Inauguración',
+      descripcion: 'México juega el primer partido en el Estadio Azteca.',
+    },
+    {
+      fecha: new Date('2026-06-27T20:00:00Z'),
+      nombre: 'Fin de la fase de grupos',
+      descripcion: 'Los 32 mejores siguen. Los demás se van a casa.',
+    },
+    {
+      fecha: new Date('2026-06-29T20:00:00Z'),
+      nombre: 'Dieciseisavos de final',
+      descripcion: 'Por primera vez en la historia: 32 equipos en eliminatorias.',
+    },
+    {
+      fecha: new Date('2026-07-04T20:00:00Z'),
+      nombre: 'Octavos de final',
+      descripcion: 'A partir de aquí, si pierdes te vas. Sin segundas oportunidades.',
+    },
+    {
+      fecha: new Date('2026-07-09T20:00:00Z'),
+      nombre: 'Cuartos de final',
+      descripcion: 'Quedan los 8 mejores del mundo.',
+    },
+    {
+      fecha: new Date('2026-07-14T20:00:00Z'),
+      nombre: 'Semifinales',
+      descripcion: 'Solo 4 selecciones siguen vivas.',
+    },
+    {
+      fecha: new Date('2026-07-18T20:00:00Z'),
+      nombre: 'Partido por el tercer puesto',
+      descripcion: 'Los dos que perdieron en semifinales juegan por la medalla de bronce.',
+    },
+    {
+      fecha: new Date('2026-07-19T19:00:00Z'),
+      nombre: 'Final',
+      descripcion: 'Estadio MetLife, Nueva Jersey. El partido más esperado del año.',
+    },
+  ],
+};
+
+const MS_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * `true` si la página debe mostrar la cara "live" (resultados/tablas/goleadores).
+ * `false` si debe mostrar la cara "previa" (educativa).
+ */
+export function isMundialActive(now: Date = new Date(), t: Tournament = MUNDIAL_2026): boolean {
+  const start = new Date(t.inauguracion.getTime() - t.previaDias * MS_DAY);
+  const end = new Date(t.final.getTime() + t.postFinalDias * MS_DAY);
+  return now >= start && now <= end;
+}
+
+/** Días enteros que faltan para la inauguración. `0` si ya empezó, negativo si ya terminó. */
+export function daysToKickoff(now: Date = new Date(), t: Tournament = MUNDIAL_2026): number {
+  return Math.ceil((t.inauguracion.getTime() - now.getTime()) / MS_DAY);
+}
+
+/** Días enteros que faltan para la final. */
+export function daysToFinal(now: Date = new Date(), t: Tournament = MUNDIAL_2026): number {
+  return Math.ceil((t.final.getTime() - now.getTime()) / MS_DAY);
+}
+
+/** Devuelve el próximo hito futuro o `null` si el torneo terminó. */
+export function nextHito(now: Date = new Date(), t: Tournament = MUNDIAL_2026) {
+  return t.hitos.find(h => h.fecha.getTime() > now.getTime()) ?? null;
+}

--- a/src/lib/mundial/format.ts
+++ b/src/lib/mundial/format.ts
@@ -1,0 +1,46 @@
+/**
+ * Formateo de tiempo para el Mundial. Siempre en español, hora local del
+ * navegador (no del servidor) para que el padre en Madrid no vea kickoffs
+ * en UTC y el peque en CDMX vea hora de México sin esfuerzo.
+ *
+ * En el servidor (SSR/SSG) `new Date()` es UTC del runner — para componentes
+ * server-rendered, formatear con `Date.toLocaleString('es-ES', { timeZone })`
+ * pasando una zona explícita si quieres pinarla. Los islands client-side
+ * usan zona local automáticamente.
+ */
+
+/** "20:00" — hora local del usuario. */
+export function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' });
+}
+
+/** "vie 12 jun · 20:00" — fecha + hora local. */
+export function fmtDateTime(iso: string | Date): string {
+  const d = typeof iso === 'string' ? new Date(iso) : iso;
+  const fecha = d.toLocaleDateString('es-ES', { weekday: 'short', day: 'numeric', month: 'short' }).replace('.', '');
+  const hora = d.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' });
+  return `${fecha} · ${hora}`;
+}
+
+/** "11 jun 2026" — solo día. */
+export function fmtDate(d: Date): string {
+  return d.toLocaleDateString('es-ES', { day: 'numeric', month: 'short', year: 'numeric' }).replace('.', '');
+}
+
+/**
+ * Cuenta atrás humana hasta un instante futuro.
+ * - >24h → "en 3d 4h"
+ * - >1h  → "en 2h 15m"
+ * - <1h  → "en 25 min"
+ * - pasado → `null` (el caller decide qué mostrar: "EN VIVO" / "FINAL")
+ */
+export function fmtCountdown(iso: string | Date): string | null {
+  const target = typeof iso === 'string' ? new Date(iso) : iso;
+  const ms = target.getTime() - Date.now();
+  if (ms < 0) return null;
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  if (h > 24) return `en ${Math.floor(h / 24)}d ${h % 24}h`;
+  if (h > 0) return `en ${h}h ${m}m`;
+  return `en ${m} min`;
+}

--- a/src/lib/mundial/grupos.ts
+++ b/src/lib/mundial/grupos.ts
@@ -1,0 +1,43 @@
+import type { Grupo } from './types';
+
+/**
+ * ⚠ DATOS PROVISIONALES — sorteo oficial FIFA del 5 dic 2025.
+ *
+ * Esta es una distribución plausible basada en el sistema de bombos
+ * (anfitriones + ranking FIFA), NO el sorteo final confirmado al 100%.
+ * Antes del 11 jun 2026, verificar grupo por grupo contra
+ * https://www.fifa.com/fifaplus/es/tournaments/mens/worldcup/canadamexicousa2026
+ * y corregir aquí. El resto del código no depende del orden ni de la
+ * pertenencia — solo de las claves ISO3 (que están todas en
+ * `selecciones.ts`).
+ *
+ * Formato 2026: 12 grupos × 4 selecciones = 48 equipos. Pasan a la fase
+ * final 32: los 2 primeros de cada grupo (24) + los 8 mejores terceros.
+ */
+export const GRUPOS: readonly Grupo[] = [
+  { letra: 'A', equipos: ['MEX', 'POR', 'POL', 'NZL'] }, // anfitrión 1: México
+  { letra: 'B', equipos: ['CAN', 'BEL', 'KOR', 'CRC'] }, // anfitrión 2: Canadá
+  { letra: 'C', equipos: ['USA', 'NED', 'AUS', 'PAN'] }, // anfitrión 3: USA
+  { letra: 'D', equipos: ['ARG', 'CRO', 'MAR', 'JAM'] },
+  { letra: 'E', equipos: ['BRA', 'ENG', 'JPN', 'ECU'] },
+  { letra: 'F', equipos: ['ESP', 'GER', 'IRN', 'PAR'] },
+  { letra: 'G', equipos: ['FRA', 'ITA', 'EGY', 'CIV'] },
+  { letra: 'H', equipos: ['HUN', 'SUI', 'SEN', 'UZB'] },
+  { letra: 'I', equipos: ['COL', 'DEN', 'NGA', 'QAT'] },
+  { letra: 'J', equipos: ['URU', 'AUT', 'GHA', 'KSA'] },
+  { letra: 'K', equipos: ['NOR', 'TUR', 'CMR', 'JOR'] },
+  { letra: 'L', equipos: ['SVK', 'TUN', 'ALG', 'HON'] },
+] as const;
+
+/** Lookup por letra. */
+export function getGrupo(letra: string): Grupo | null {
+  return GRUPOS.find(g => g.letra === letra) ?? null;
+}
+
+/** Devuelve la letra del grupo en el que está un equipo, o `null`. */
+export function grupoDeEquipo(code: string): string | null {
+  return GRUPOS.find(g => g.equipos.includes(code))?.letra ?? null;
+}
+
+/** Las 48 selecciones del torneo en un array plano (para listados, encuestas, etc). */
+export const SELECCIONES_DEL_TORNEO: readonly string[] = GRUPOS.flatMap(g => g.equipos);

--- a/src/lib/mundial/mock.ts
+++ b/src/lib/mundial/mock.ts
@@ -1,0 +1,57 @@
+import type { Match, Standing, Scorer } from './types';
+
+/**
+ * ⚠ DATOS MOCK — NO EXPONER EN PRODUCCIÓN HASTA QUE EMPIECE EL TORNEO.
+ *
+ * Este módulo solo se importa desde componentes que comprueban
+ * `isMundialActive()` y/o desde tests/dev preview. Sirve para validar UI
+ * de live/tablas/goleadores antes del 11 jun 2026.
+ *
+ * Cuando la API real esté lista (`src/lib/mundial/api.ts`, Fase 6):
+ * - en dev → seguir usando este mock por defecto.
+ * - en prod → fetch a football-data.org con cache, fallback al mock si falla.
+ *
+ * Los `kickoff` son relativos a `Date.now()` (no fechas duras) para que la
+ * demo siempre tenga 2 partidos "en vivo" y 4 "próximos" al cargar.
+ */
+
+const inMin = (m: number) => new Date(Date.now() + m * 60_000).toISOString();
+
+export const PARTIDOS_MOCK: ReadonlyArray<Match> = [
+  { id: 'm1', fase: 'Grupos · J1', grupo: 'A', home: 'MEX', away: 'POL', homeScore: 2, awayScore: 1, status: 'finished', kickoff: inMin(-180), venue: 'Azteca, CDMX',         minute: 90 },
+  { id: 'm2', fase: 'Grupos · J1', grupo: 'C', home: 'USA', away: 'NED', homeScore: 1, awayScore: 1, status: 'live',     kickoff: inMin(-65),  venue: 'MetLife, NJ',         minute: 67 },
+  { id: 'm3', fase: 'Grupos · J1', grupo: 'F', home: 'ESP', away: 'GER', homeScore: 0, awayScore: 0, status: 'live',     kickoff: inMin(-12),  venue: 'SoFi, LA',            minute: 14 },
+  { id: 'm4', fase: 'Grupos · J1', grupo: 'D', home: 'ARG', away: 'CRO', homeScore: null, awayScore: null, status: 'scheduled', kickoff: inMin(125),  venue: 'Estadio BBVA, MTY' },
+  { id: 'm5', fase: 'Grupos · J1', grupo: 'E', home: 'BRA', away: 'ENG', homeScore: null, awayScore: null, status: 'scheduled', kickoff: inMin(280),  venue: 'AT&T, Dallas' },
+  { id: 'm6', fase: 'Grupos · J1', grupo: 'G', home: 'FRA', away: 'ITA', homeScore: null, awayScore: null, status: 'scheduled', kickoff: inMin(425),  venue: 'Mercedes-Benz, ATL' },
+  { id: 'm7', fase: 'Grupos · J1', grupo: 'B', home: 'CAN', away: 'BEL', homeScore: null, awayScore: null, status: 'scheduled', kickoff: inMin(1440), venue: 'BMO Field, Toronto' },
+  { id: 'm8', fase: 'Grupos · J1', grupo: 'A', home: 'POR', away: 'NZL', homeScore: null, awayScore: null, status: 'scheduled', kickoff: inMin(1580), venue: "Levi's, SF" },
+];
+
+export const TABLAS_MOCK: Readonly<Record<string, ReadonlyArray<Standing>>> = {
+  A: [
+    { team: 'MEX', pj: 1, g: 1, e: 0, p: 0, gf: 2, gc: 1, pts: 3 },
+    { team: 'POR', pj: 0, g: 0, e: 0, p: 0, gf: 0, gc: 0, pts: 0 },
+    { team: 'POL', pj: 1, g: 0, e: 0, p: 1, gf: 1, gc: 2, pts: 0 },
+    { team: 'NZL', pj: 0, g: 0, e: 0, p: 0, gf: 0, gc: 0, pts: 0 },
+  ],
+  C: [
+    { team: 'USA', pj: 1, g: 0, e: 1, p: 0, gf: 1, gc: 1, pts: 1 },
+    { team: 'NED', pj: 1, g: 0, e: 1, p: 0, gf: 1, gc: 1, pts: 1 },
+    { team: 'AUS', pj: 0, g: 0, e: 0, p: 0, gf: 0, gc: 0, pts: 0 },
+    { team: 'PAN', pj: 0, g: 0, e: 0, p: 0, gf: 0, gc: 0, pts: 0 },
+  ],
+  F: [
+    { team: 'ESP', pj: 0, g: 0, e: 0, p: 0, gf: 0, gc: 0, pts: 0 },
+    { team: 'GER', pj: 0, g: 0, e: 0, p: 0, gf: 0, gc: 0, pts: 0 },
+    { team: 'IRN', pj: 0, g: 0, e: 0, p: 0, gf: 0, gc: 0, pts: 0 },
+    { team: 'PAR', pj: 0, g: 0, e: 0, p: 0, gf: 0, gc: 0, pts: 0 },
+  ],
+};
+
+export const GOLEADORES_MOCK: ReadonlyArray<Scorer> = [
+  { player: 'Santi Giménez',     team: 'MEX', goles: 2, curiosidad: 'lleva el dorsal 9, como Hugo Sánchez' },
+  { player: 'Robert Lewandowski', team: 'POL', goles: 1, curiosidad: 'tiene 37 años — el goleador más mayor del torneo' },
+  { player: 'Christian Pulisic', team: 'USA', goles: 1, curiosidad: 'capitán de su selección con solo 27 años' },
+  { player: 'Cody Gakpo',        team: 'NED', goles: 1, curiosidad: 'extremo izquierdo, marcó en el Mundial 2022' },
+];

--- a/src/lib/mundial/selecciones.ts
+++ b/src/lib/mundial/selecciones.ts
@@ -1,0 +1,121 @@
+import type { Team } from './types';
+
+/**
+ * Mapa ISO 3166-1 alpha-3 → alpha-2 para flagcdn.com.
+ * Caso especial: `gb-eng` (Inglaterra) — Escocia/Gales/Irlanda Norte tienen su propio
+ * subdivision code en flagcdn.
+ *
+ * Cubre todas las selecciones con posibilidad real de clasificarse al Mundial 2026.
+ * Si una selección no aparece, ampliar aquí — `<Flag>` ya cae a un chip con código si
+ * el iso2 falta o el SVG falla en cargar.
+ */
+export const ISO3_TO_ISO2: Readonly<Record<string, string>> = {
+  // Anfitriones
+  USA: 'us', MEX: 'mx', CAN: 'ca',
+  // UEFA
+  ESP: 'es', FRA: 'fr', ENG: 'gb-eng', GER: 'de', ITA: 'it', NED: 'nl', POR: 'pt',
+  BEL: 'be', CRO: 'hr', SUI: 'ch', DEN: 'dk', AUT: 'at', POL: 'pl', NOR: 'no',
+  CZE: 'cz', TUR: 'tr', SWE: 'se', SRB: 'rs', UKR: 'ua', SCO: 'gb-sct', HUN: 'hu',
+  WAL: 'gb-wls', SVK: 'sk',
+  // CONMEBOL
+  ARG: 'ar', BRA: 'br', URU: 'uy', COL: 'co', ECU: 'ec', PAR: 'py', VEN: 've', BOL: 'bo',
+  // AFC
+  JPN: 'jp', KOR: 'kr', IRN: 'ir', KSA: 'sa', AUS: 'au', QAT: 'qa', IRQ: 'iq',
+  UAE: 'ae', UZB: 'uz', JOR: 'jo',
+  // CAF
+  MAR: 'ma', SEN: 'sn', EGY: 'eg', NGA: 'ng', ALG: 'dz', TUN: 'tn', CMR: 'cm',
+  GHA: 'gh', CIV: 'ci', RSA: 'za', MLI: 'ml',
+  // CONCACAF
+  CRC: 'cr', PAN: 'pa', JAM: 'jm', HON: 'hn',
+  // OFC
+  NZL: 'nz',
+};
+
+/**
+ * Catálogo de equipos. `color` se usa solo para el chip de fallback cuando
+ * flagcdn.com no carga (red móvil flaky), nunca como decoración primaria —
+ * la bandera es la identidad.
+ *
+ * Lista exhaustiva de todas las selecciones con metadata, NO lista de
+ * clasificadas. El sorteo de 12 grupos × 4 vive en `grupos.ts`.
+ */
+export const SELECCIONES: Readonly<Record<string, Team>> = {
+  // ─── Anfitriones ────────────────────────────────────────────
+  USA: { code: 'USA', iso2: 'us', nombre: 'Estados Unidos', color: '#bf0a30', confederation: 'CONCACAF' },
+  MEX: { code: 'MEX', iso2: 'mx', nombre: 'México',         color: '#006847', confederation: 'CONCACAF' },
+  CAN: { code: 'CAN', iso2: 'ca', nombre: 'Canadá',         color: '#d52b1e', confederation: 'CONCACAF' },
+
+  // ─── UEFA ───────────────────────────────────────────────────
+  ESP: { code: 'ESP', iso2: 'es',     nombre: 'España',           color: '#c60b1e', confederation: 'UEFA' },
+  FRA: { code: 'FRA', iso2: 'fr',     nombre: 'Francia',          color: '#0055a4', confederation: 'UEFA' },
+  ENG: { code: 'ENG', iso2: 'gb-eng', nombre: 'Inglaterra',       color: '#cf102d', confederation: 'UEFA' },
+  GER: { code: 'GER', iso2: 'de',     nombre: 'Alemania',         color: '#1a1a1a', confederation: 'UEFA' },
+  ITA: { code: 'ITA', iso2: 'it',     nombre: 'Italia',           color: '#008c45', confederation: 'UEFA' },
+  NED: { code: 'NED', iso2: 'nl',     nombre: 'Países Bajos',     color: '#ae1c28', confederation: 'UEFA' },
+  POR: { code: 'POR', iso2: 'pt',     nombre: 'Portugal',         color: '#006633', confederation: 'UEFA' },
+  BEL: { code: 'BEL', iso2: 'be',     nombre: 'Bélgica',          color: '#fdda24', confederation: 'UEFA' },
+  CRO: { code: 'CRO', iso2: 'hr',     nombre: 'Croacia',          color: '#171796', confederation: 'UEFA' },
+  SUI: { code: 'SUI', iso2: 'ch',     nombre: 'Suiza',            color: '#dc2626', confederation: 'UEFA' },
+  DEN: { code: 'DEN', iso2: 'dk',     nombre: 'Dinamarca',        color: '#c8102e', confederation: 'UEFA' },
+  AUT: { code: 'AUT', iso2: 'at',     nombre: 'Austria',          color: '#ed2939', confederation: 'UEFA' },
+  POL: { code: 'POL', iso2: 'pl',     nombre: 'Polonia',          color: '#dc143c', confederation: 'UEFA' },
+  NOR: { code: 'NOR', iso2: 'no',     nombre: 'Noruega',          color: '#ba0c2f', confederation: 'UEFA' },
+  CZE: { code: 'CZE', iso2: 'cz',     nombre: 'Chequia',          color: '#11457e', confederation: 'UEFA' },
+  TUR: { code: 'TUR', iso2: 'tr',     nombre: 'Turquía',          color: '#e30a17', confederation: 'UEFA' },
+  SWE: { code: 'SWE', iso2: 'se',     nombre: 'Suecia',           color: '#006aa7', confederation: 'UEFA' },
+  SRB: { code: 'SRB', iso2: 'rs',     nombre: 'Serbia',           color: '#c6363c', confederation: 'UEFA' },
+  UKR: { code: 'UKR', iso2: 'ua',     nombre: 'Ucrania',          color: '#005bbb', confederation: 'UEFA' },
+  SCO: { code: 'SCO', iso2: 'gb-sct', nombre: 'Escocia',          color: '#0065bd', confederation: 'UEFA' },
+  HUN: { code: 'HUN', iso2: 'hu',     nombre: 'Hungría',          color: '#477050', confederation: 'UEFA' },
+  WAL: { code: 'WAL', iso2: 'gb-wls', nombre: 'Gales',            color: '#d30731', confederation: 'UEFA' },
+  SVK: { code: 'SVK', iso2: 'sk',     nombre: 'Eslovaquia',       color: '#0b4ea2', confederation: 'UEFA' },
+
+  // ─── CONMEBOL ───────────────────────────────────────────────
+  ARG: { code: 'ARG', iso2: 'ar', nombre: 'Argentina',  color: '#74acdf', confederation: 'CONMEBOL' },
+  BRA: { code: 'BRA', iso2: 'br', nombre: 'Brasil',     color: '#fedf00', confederation: 'CONMEBOL' },
+  URU: { code: 'URU', iso2: 'uy', nombre: 'Uruguay',    color: '#7b9eff', confederation: 'CONMEBOL' },
+  COL: { code: 'COL', iso2: 'co', nombre: 'Colombia',   color: '#fcd116', confederation: 'CONMEBOL' },
+  ECU: { code: 'ECU', iso2: 'ec', nombre: 'Ecuador',    color: '#ffd700', confederation: 'CONMEBOL' },
+  PAR: { code: 'PAR', iso2: 'py', nombre: 'Paraguay',   color: '#d52b1e', confederation: 'CONMEBOL' },
+  VEN: { code: 'VEN', iso2: 've', nombre: 'Venezuela',  color: '#7b1e3a', confederation: 'CONMEBOL' },
+  BOL: { code: 'BOL', iso2: 'bo', nombre: 'Bolivia',    color: '#007934', confederation: 'CONMEBOL' },
+
+  // ─── AFC ────────────────────────────────────────────────────
+  JPN: { code: 'JPN', iso2: 'jp', nombre: 'Japón',           color: '#bc002d', confederation: 'AFC' },
+  KOR: { code: 'KOR', iso2: 'kr', nombre: 'Corea del Sur',   color: '#0047a0', confederation: 'AFC' },
+  IRN: { code: 'IRN', iso2: 'ir', nombre: 'Irán',            color: '#239f40', confederation: 'AFC' },
+  KSA: { code: 'KSA', iso2: 'sa', nombre: 'Arabia Saudí',    color: '#006c35', confederation: 'AFC' },
+  AUS: { code: 'AUS', iso2: 'au', nombre: 'Australia',       color: '#ffc72c', confederation: 'AFC' },
+  QAT: { code: 'QAT', iso2: 'qa', nombre: 'Catar',           color: '#8a1538', confederation: 'AFC' },
+  IRQ: { code: 'IRQ', iso2: 'iq', nombre: 'Irak',            color: '#cd1126', confederation: 'AFC' },
+  UAE: { code: 'UAE', iso2: 'ae', nombre: 'Emiratos Árabes', color: '#00732f', confederation: 'AFC' },
+  UZB: { code: 'UZB', iso2: 'uz', nombre: 'Uzbekistán',      color: '#0099b5', confederation: 'AFC' },
+  JOR: { code: 'JOR', iso2: 'jo', nombre: 'Jordania',        color: '#007a3d', confederation: 'AFC' },
+
+  // ─── CAF ────────────────────────────────────────────────────
+  MAR: { code: 'MAR', iso2: 'ma', nombre: 'Marruecos',     color: '#c1272d', confederation: 'CAF' },
+  SEN: { code: 'SEN', iso2: 'sn', nombre: 'Senegal',       color: '#00853f', confederation: 'CAF' },
+  EGY: { code: 'EGY', iso2: 'eg', nombre: 'Egipto',        color: '#c8102e', confederation: 'CAF' },
+  NGA: { code: 'NGA', iso2: 'ng', nombre: 'Nigeria',       color: '#008751', confederation: 'CAF' },
+  ALG: { code: 'ALG', iso2: 'dz', nombre: 'Argelia',       color: '#006633', confederation: 'CAF' },
+  TUN: { code: 'TUN', iso2: 'tn', nombre: 'Túnez',         color: '#e70013', confederation: 'CAF' },
+  CMR: { code: 'CMR', iso2: 'cm', nombre: 'Camerún',       color: '#007a5e', confederation: 'CAF' },
+  GHA: { code: 'GHA', iso2: 'gh', nombre: 'Ghana',         color: '#006b3f', confederation: 'CAF' },
+  CIV: { code: 'CIV', iso2: 'ci', nombre: 'Costa de Marfil', color: '#ff8200', confederation: 'CAF' },
+  RSA: { code: 'RSA', iso2: 'za', nombre: 'Sudáfrica',     color: '#007a4d', confederation: 'CAF' },
+  MLI: { code: 'MLI', iso2: 'ml', nombre: 'Malí',          color: '#fcd116', confederation: 'CAF' },
+
+  // ─── CONCACAF (no anfitriones) ──────────────────────────────
+  CRC: { code: 'CRC', iso2: 'cr', nombre: 'Costa Rica',     color: '#002b7f', confederation: 'CONCACAF' },
+  PAN: { code: 'PAN', iso2: 'pa', nombre: 'Panamá',         color: '#005aa7', confederation: 'CONCACAF' },
+  JAM: { code: 'JAM', iso2: 'jm', nombre: 'Jamaica',        color: '#009b3a', confederation: 'CONCACAF' },
+  HON: { code: 'HON', iso2: 'hn', nombre: 'Honduras',       color: '#0073cf', confederation: 'CONCACAF' },
+
+  // ─── OFC ────────────────────────────────────────────────────
+  NZL: { code: 'NZL', iso2: 'nz', nombre: 'Nueva Zelanda',  color: '#012169', confederation: 'OFC' },
+};
+
+/** Helper para obtener equipo o `null` si el código no existe. */
+export function getTeam(code: string): Team | null {
+  return SELECCIONES[code] ?? null;
+}

--- a/src/lib/mundial/types.ts
+++ b/src/lib/mundial/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Tipos del dominio "Mundial" — diseñados para reutilizar en torneos futuros
+ * (Mundial femenino 2027, Copa América, etc). El `tournament` viene de dates.ts
+ * por separado para no acoplar los datos a un campeonato concreto.
+ */
+
+export type MatchStatus = 'scheduled' | 'live' | 'finished';
+
+export type Confederation = 'UEFA' | 'CONMEBOL' | 'CONCACAF' | 'AFC' | 'CAF' | 'OFC';
+
+export type Team = {
+  /** ISO 3166-1 alpha-3 — `ESP`, `ARG`, `BRA`… (clave primaria) */
+  code: string;
+  /** ISO 3166-1 alpha-2 — para flagcdn.com. `gb-eng` para Inglaterra. */
+  iso2: string;
+  nombre: string;
+  /** Color brand del equipo, hex sin `#`-tag tokens (se usa para fallback de bandera). */
+  color: string;
+  confederation: Confederation;
+};
+
+export type Grupo = {
+  /** Letra del grupo: 'A', 'B', …, 'L'. 12 grupos en el formato de 48 selecciones. */
+  letra: string;
+  /** Códigos ISO3 de las 4 selecciones del grupo. */
+  equipos: [string, string, string, string];
+};
+
+export type Match = {
+  id: string;
+  /** "Grupos · J1" | "Octavos" | "Cuartos" | "Semifinal" | "Final" */
+  fase: string;
+  /** Letra del grupo. Solo en fase de grupos. */
+  grupo?: string;
+  /** ISO3 */
+  home: string;
+  /** ISO3 */
+  away: string;
+  homeScore: number | null;
+  awayScore: number | null;
+  status: MatchStatus;
+  /** ISO UTC */
+  kickoff: string;
+  venue?: string;
+  /** Solo cuando `status === 'live'`. */
+  minute?: number;
+};
+
+export type Standing = {
+  /** ISO3 */
+  team: string;
+  pj: number;
+  g: number;
+  e: number;
+  p: number;
+  gf: number;
+  gc: number;
+  pts: number;
+};
+
+export type Scorer = {
+  player: string;
+  /** ISO3 */
+  team: string;
+  goles: number;
+  /** Dato curioso manuscrito ("jugador #9", "extremo izq.", "capitán"). */
+  curiosidad: string;
+};
+
+/** Voto de la encuesta "¿quién crees que ganará?" — se guarda en localStorage. */
+export type Vote = {
+  /** ISO3 elegido por el usuario. Solo se permite un voto por dispositivo. */
+  team: string;
+  /** Timestamp UTC para auditoría local. */
+  at: string;
+};

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -125,6 +125,77 @@ export function personJsonLd({
   return JSON.stringify(schema);
 }
 
+interface FaqEntry {
+  q: string;
+  a: string;
+}
+
+/**
+ * JSON-LD `FAQPage` para páginas con secciones explicativas (¿qué es X?).
+ * Google puede mostrar las preguntas como featured snippets / rich results.
+ * Las preguntas y respuestas deben ser texto plano sin HTML.
+ */
+export function faqJsonLd(entries: ReadonlyArray<FaqEntry>): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: entries.map(({ q, a }) => ({
+      '@type': 'Question',
+      name: q,
+      acceptedAnswer: { '@type': 'Answer', text: a },
+    })),
+  });
+}
+
+interface SportsEventProps {
+  name: string;
+  description: string;
+  url: string;
+  startDate: Date;
+  endDate: Date;
+  /** Lista de países anfitriones (nombres legibles). */
+  hostCountries: ReadonlyArray<string>;
+  /** Estado del evento. Por defecto `EventScheduled`. */
+  status?: 'EventScheduled' | 'EventPostponed' | 'EventRescheduled' | 'EventCancelled';
+}
+
+/**
+ * JSON-LD `SportsEvent` para representar el torneo completo. Los partidos
+ * individuales se añadirán como `subEvents` cuando se conozcan las
+ * alineaciones y la API esté integrada (Fase 6).
+ */
+export function sportsEventJsonLd({
+  name,
+  description,
+  url,
+  startDate,
+  endDate,
+  hostCountries,
+  status = 'EventScheduled',
+}: SportsEventProps): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'SportsEvent',
+    name,
+    description,
+    url,
+    startDate: startDate.toISOString(),
+    endDate: endDate.toISOString(),
+    eventStatus: `https://schema.org/${status}`,
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    sport: 'Football',
+    location: hostCountries.map((country) => ({
+      '@type': 'Country',
+      name: country,
+    })),
+    organizer: {
+      '@type': 'SportsOrganization',
+      name: 'FIFA',
+      url: 'https://www.fifa.com/',
+    },
+  });
+}
+
 export function getReadingTime(content: string): number {
   const wordsPerMinute = 200;
   const words = content.trim().split(/\s+/).length;

--- a/src/pages/[categoria]/index.astro
+++ b/src/pages/[categoria]/index.astro
@@ -3,10 +3,15 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 import CategoryLayout from '@/layouts/CategoryLayout.astro';
 
 export async function getStaticPaths() {
-  const categorias = await getCollection('categorias');
+  // `mundial-2026` tiene su propia página en src/pages/mundial-2026/index.astro
+  // (no es solo listado de artículos — incluye hero, secciones educativas,
+  // encuesta y, durante el torneo, resultados). Excluida aquí para no chocar.
+  const categorias = (await getCollection('categorias')).filter(
+    (c: CollectionEntry<'categorias'>) => c.data.slug !== 'mundial-2026',
+  );
   const articulos = await getCollection(
     'articulos',
-    ({ data }: CollectionEntry<'articulos'>) => !data.draft
+    ({ data }: CollectionEntry<'articulos'>) => !data.draft,
   );
 
   return categorias.map((categoria: CollectionEntry<'categorias'>) => {

--- a/src/pages/mundial-2026/index.astro
+++ b/src/pages/mundial-2026/index.astro
@@ -1,0 +1,393 @@
+---
+import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
+import '@/styles/mundial.css';
+
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import Header from '@/components/Header.astro';
+import Footer from '@/components/Footer.astro';
+import Breadcrumb from '@/components/Breadcrumb.astro';
+import ArticleCard from '@/components/ArticleCard.astro';
+import AdSlot from '@/components/AdSlot.astro';
+
+import QueEsElMundial from '@/components/mundial/QueEsElMundial.astro';
+import ComoFunciona from '@/components/mundial/ComoFunciona.astro';
+import GruposGrid from '@/components/mundial/GruposGrid.astro';
+import CalendarioHitos from '@/components/mundial/CalendarioHitos.astro';
+import HistoriaCuriosa from '@/components/mundial/HistoriaCuriosa.astro';
+import EncuestaCampeon from '@/components/mundial/EncuestaCampeon';
+
+import { SITE_URL } from '@/consts';
+import { categoryColorVar } from '@/lib/categories';
+import { faqJsonLd, sportsEventJsonLd } from '@/lib/seo';
+import {
+  MUNDIAL_2026,
+  daysToKickoff,
+  daysToFinal,
+  isMundialActive,
+  nextHito,
+} from '@/lib/mundial/dates';
+
+const categoria = await getEntry('categorias', 'mundial-2026');
+if (!categoria) {
+  throw new Error('Falta la categoría mundial-2026 en src/content/categorias/');
+}
+
+const articulos = await getCollection(
+  'articulos',
+  ({ data }: CollectionEntry<'articulos'>) =>
+    !data.draft && data.categoria === 'mundial-2026',
+);
+const articulosOrdenados = [...articulos].sort(
+  (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
+);
+
+const now = new Date();
+const dias = Math.max(0, daysToKickoff(now));
+const diasFinal = Math.max(0, daysToFinal(now));
+const torneoActivo = isMundialActive(now);
+const proximo = nextHito(now);
+
+const colorVar = categoryColorVar(categoria.data.color);
+const dorsalNumber = String(categoria.data.orden).padStart(2, '0');
+
+const canonicalUrl = new URL('/mundial-2026/', SITE_URL).toString();
+const metaTitle = 'Mundial 2026 explicado para niños';
+const metaDescription =
+  'El Mundial 2026 contado a tu peque: qué es, cómo funciona, los 12 grupos, el calendario y la historia del torneo más importante del fútbol.';
+
+// Schema.org: las 6 preguntas más buscadas sobre el Mundial. Las respuestas
+// están sincronizadas con el cuerpo de la página — si cambia una sección,
+// actualizar también aquí para mantener consistencia.
+const faqLd = faqJsonLd([
+  {
+    q: '¿Qué es el Mundial de fútbol?',
+    a: 'El Mundial es el torneo de selecciones de fútbol más importante del planeta. Se juega cada cuatro años y enfrenta a las mejores selecciones nacionales del mundo. La selección que gana se proclama campeona del mundo durante los siguientes cuatro años.',
+  },
+  {
+    q: '¿Cuándo empieza el Mundial 2026?',
+    a: 'El Mundial 2026 comienza el 11 de junio de 2026 con el partido inaugural en el Estadio Azteca de México. La final se juega el 19 de julio de 2026 en el estadio MetLife de Nueva Jersey, Estados Unidos.',
+  },
+  {
+    q: '¿Cuántas selecciones juegan el Mundial 2026?',
+    a: 'El Mundial 2026 es el primero de la historia con 48 selecciones, repartidas en 12 grupos de 4 equipos. Hasta el Mundial de Catar 2022 jugaban 32 selecciones.',
+  },
+  {
+    q: '¿Dónde se juega el Mundial 2026?',
+    a: 'El Mundial 2026 se juega en tres países a la vez: Canadá, México y Estados Unidos. Es la primera vez en la historia del Mundial que el torneo se organiza en tres países simultáneamente, repartido en 16 ciudades.',
+  },
+  {
+    q: '¿Cómo se clasifica a la siguiente fase?',
+    a: 'En la fase de grupos, las 4 selecciones de cada grupo se enfrentan entre sí. Se llevan 3 puntos por victoria, 1 por empate y 0 por derrota. Pasan a la siguiente fase los 2 primeros de cada grupo y los 8 mejores terceros, completando los 32 clasificados a dieciseisavos.',
+  },
+  {
+    q: '¿Quién es el último campeón del Mundial?',
+    a: 'Argentina ganó el Mundial de Catar 2022 al vencer a Francia en la final. Es el tercer Mundial de Argentina, después de los ganados en 1978 y 1986.',
+  },
+]);
+
+// SportsEvent del torneo completo. Los partidos individuales se sumarán
+// como subEvents cuando la API real esté integrada (Fase 6).
+const eventLd = sportsEventJsonLd({
+  name: 'Mundial de Fútbol 2026',
+  description: metaDescription,
+  url: canonicalUrl,
+  startDate: MUNDIAL_2026.inauguracion,
+  endDate: MUNDIAL_2026.final,
+  hostCountries: ['Canadá', 'México', 'Estados Unidos'],
+});
+---
+
+<BaseLayout
+  title={metaTitle}
+  description={metaDescription}
+  canonical={canonicalUrl}
+  ogType="website"
+>
+  <Fragment slot="head">
+    <!-- flagcdn.com sirve los SVG de las 48 banderas — preconnect ahorra ~250ms de TLS. -->
+    <link rel="preconnect" href="https://flagcdn.com" crossorigin />
+    <script is:inline type="application/ld+json" set:html={faqLd} />
+    <script is:inline type="application/ld+json" set:html={eventLd} />
+  </Fragment>
+
+  <Header />
+
+  <div class="mx-auto max-w-7xl px-4 md:px-12">
+    <Breadcrumb items={[{ label: 'Mundial 2026' }]} />
+  </div>
+
+  <!-- ============ HERO ============ -->
+  <section class="mh" style={`--cat-color:${colorVar};`} aria-labelledby="mh-titulo">
+    <div class="mh__inner mx-auto max-w-7xl px-4 md:px-12">
+      <span class="mh__dorsal" aria-hidden="true">{dorsalNumber}</span>
+
+      <div class="mh__content">
+        <div class="mh__eyebrow-row">
+          <span class="mono mh__eyebrow">CANADÁ · MÉXICO · EE. UU.</span>
+          <span class="hand mh__tag">¡48 selecciones!</span>
+        </div>
+
+        <h1 id="mh-titulo" class="mh__titulo display">
+          Mundial <span class="mh__year">2026</span>.<br />
+          <span class="marker mh__marker">explicado</span> para tu peque.
+        </h1>
+
+        <p class="mh__subtitulo">
+          Del <strong>11 de junio</strong> al <strong>19 de julio</strong> de 2026.
+          Resultados, grupos, calendario e historia. Sin tecnicismos, sin spoilers.
+          Pensado para vivirlo <strong>en familia</strong>.
+        </p>
+
+        <div class="mh__stats" role="list">
+          <div class="mh__stat card-paper" role="listitem">
+            <span class="mono mh__stat-label">FALTAN</span>
+            <span class="display mh__stat-num">{dias}</span>
+            <span class="hand mh__stat-hand">días para la inauguración</span>
+          </div>
+          <div class="mh__stat card-paper" role="listitem">
+            <span class="mono mh__stat-label">SELECCIONES</span>
+            <span class="display mh__stat-num">48</span>
+            <span class="hand mh__stat-hand">países compitiendo</span>
+          </div>
+          <div class="mh__stat card-paper" role="listitem">
+            <span class="mono mh__stat-label">GRUPOS</span>
+            <span class="display mh__stat-num">12</span>
+            <span class="hand mh__stat-hand">de la A a la L</span>
+          </div>
+          <div class="mh__stat card-paper" role="listitem">
+            <span class="mono mh__stat-label">FINAL</span>
+            <span class="display mh__stat-num">{diasFinal}</span>
+            <span class="hand mh__stat-hand">días para la copa</span>
+          </div>
+        </div>
+
+        {!torneoActivo && proximo && (
+          <p class="mh__proximo mono">
+            PRÓXIMO HITO · <strong>{proximo.nombre}</strong> · {proximo.descripcion}
+          </p>
+        )}
+      </div>
+    </div>
+    <div class="divider-pitch"></div>
+  </section>
+
+  <main id="main" class="mx-auto max-w-7xl px-4 pb-14 md:px-12 md:pb-20">
+    <!-- ============ SECCIONES EDUCATIVAS ============ -->
+    <QueEsElMundial />
+    <ComoFunciona />
+
+    <AdSlot id="mundial-mid-1" format="horizontal" />
+
+    <GruposGrid />
+    <CalendarioHitos />
+    <HistoriaCuriosa />
+
+    <AdSlot id="mundial-mid-2" format="horizontal" />
+
+    <!-- ============ ENCUESTA (isla Preact) ============ -->
+    <EncuestaCampeon client:visible />
+
+    <!-- ============ ARTÍCULOS EDITORIALES ============ -->
+    {articulosOrdenados.length > 0 && (
+      <section class="mh-articulos" aria-labelledby="mh-articulos-titulo">
+        <div class="mh-articulos__header">
+          <span class="mono mh-articulos__eyebrow">07 · MÁS SOBRE EL MUNDIAL</span>
+          <h2 id="mh-articulos-titulo" class="display mh-articulos__titulo">
+            Artículos para <span class="marker">leer juntos</span>
+          </h2>
+          <p class="mh-articulos__intro">
+            Guías y curiosidades que hemos preparado para que tu peque entienda
+            cada rincón del torneo.
+          </p>
+        </div>
+
+        <div class="mh-articulos__grid">
+          {articulosOrdenados.map((article, i) => (
+            <ArticleCard
+              article={article}
+              categoriaColor={categoria.data.color}
+              categoriaNombre={categoria.data.nombre}
+              loading={i < 3 ? 'eager' : 'lazy'}
+              hideCategoryChip
+            />
+          ))}
+        </div>
+      </section>
+    )}
+
+    <AdSlot id="mundial-bottom" format="horizontal" />
+  </main>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  /* ───────── Hero del Mundial ───────── */
+  .mh {
+    position: relative;
+    border-bottom: 2px solid var(--color-foreground);
+    background:
+      radial-gradient(circle at 0% 0%, color-mix(in oklab, var(--cat-color), transparent 88%) 0%, transparent 55%),
+      radial-gradient(circle at 100% 100%, color-mix(in oklab, var(--color-accent), transparent 92%) 0%, transparent 55%),
+      var(--color-background);
+    overflow: hidden;
+  }
+  .mh__inner {
+    display: grid;
+    grid-template-columns: 1fr;
+    align-items: center;
+    gap: 16px;
+    padding-top: 28px;
+    padding-bottom: 36px;
+  }
+  .mh__dorsal {
+    font-family: var(--font-display);
+    font-weight: 700;
+    color: var(--cat-color);
+    line-height: 0.85;
+    font-size: clamp(96px, 24vw, 240px);
+    letter-spacing: -0.04em;
+    user-select: none;
+    display: block;
+  }
+  .mh__content {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    min-width: 0;
+  }
+  .mh__eyebrow-row {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+  .mh__eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    color: var(--color-foreground-subtle);
+  }
+  .mh__tag {
+    font-size: 22px;
+    color: var(--color-handwritten);
+    transform: rotate(-3deg);
+    display: inline-block;
+  }
+  .mh__titulo {
+    font-size: clamp(2.5rem, 7vw, 5rem);
+    line-height: 0.95;
+    margin: 0;
+    letter-spacing: -0.025em;
+  }
+  .mh__year {
+    color: var(--cat-color);
+  }
+  .mh__marker {
+    /* heredada de .marker global — aquí solo sobre-escribimos si hace falta */
+  }
+  .mh__subtitulo {
+    margin: 0;
+    color: var(--color-foreground-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    max-width: 60ch;
+  }
+  .mh__stats {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+    margin-top: 8px;
+  }
+  .mh__stat {
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: flex-start;
+  }
+  .mh__stat-label {
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    color: var(--color-foreground-subtle);
+  }
+  .mh__stat-num {
+    font-size: clamp(2.25rem, 5vw, 3rem);
+    line-height: 0.95;
+    color: var(--cat-color);
+  }
+  .mh__stat:nth-child(2) .mh__stat-num { color: var(--color-foreground); }
+  .mh__stat:nth-child(3) .mh__stat-num { color: var(--color-secondary); }
+  .mh__stat:nth-child(4) .mh__stat-num { color: var(--color-accent); }
+  .mh__stat-hand {
+    font-size: 16px;
+    color: var(--color-handwritten);
+    line-height: 1.1;
+    margin-top: 2px;
+  }
+  .mh__proximo {
+    margin-top: 8px;
+    padding: 10px 14px;
+    background: var(--color-surface-alt);
+    border-radius: var(--radius-md);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    color: var(--color-foreground-muted);
+  }
+  .mh__proximo strong {
+    color: var(--color-foreground);
+    text-transform: uppercase;
+    margin-right: 4px;
+  }
+
+  @media (min-width: 768px) {
+    .mh__inner {
+      grid-template-columns: auto 1fr;
+      gap: 28px;
+      padding-top: 56px;
+      padding-bottom: 56px;
+    }
+    .mh__stats {
+      grid-template-columns: repeat(4, 1fr);
+    }
+    .mh__subtitulo {
+      font-size: 1.1rem;
+    }
+  }
+
+  /* ───────── Bloque de artículos editoriales ───────── */
+  .mh-articulos {
+    margin-top: 64px;
+  }
+  .mh-articulos__header {
+    max-width: 60ch;
+    margin-bottom: 24px;
+  }
+  .mh-articulos__eyebrow {
+    display: inline-block;
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    color: var(--color-foreground-subtle);
+    margin-bottom: 8px;
+  }
+  .mh-articulos__titulo {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    margin: 0 0 14px;
+  }
+  .mh-articulos__intro {
+    color: var(--color-foreground-muted);
+    font-size: 1rem;
+    line-height: 1.55;
+    margin: 0;
+  }
+  .mh-articulos__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    margin-top: 22px;
+  }
+  @media (min-width: 1024px) {
+    .mh-articulos__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/src/styles/mundial.css
+++ b/src/styles/mundial.css
@@ -1,0 +1,526 @@
+/**
+ * Estilos para las islas Preact del Mundial.
+ * Los componentes .tsx no tienen `<style>` scoped, así que sus clases viven
+ * aquí. Solo se importa desde páginas/layouts que usan estos componentes
+ * (no en el global del sitio).
+ *
+ * Naming: prefijos `tickerb__`, `tickers__`, `encuesta__` — sin colisión
+ * con clases del proyecto base.
+ */
+
+/* ────────────────────────────────────────────────────────────────
+ * TickerBolsa — barra negra superior con scroll horizontal infinito.
+ * ──────────────────────────────────────────────────────────────── */
+
+.tickerb {
+  position: relative;
+  background: #0a0d14;
+  color: #fffcf1;
+  border-bottom: 1px solid #2a3344;
+  overflow: hidden;
+}
+.tickerb__inner {
+  display: flex;
+  align-items: center;
+  height: 40px;
+}
+.tickerb__pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 14px;
+  height: 100%;
+  background: #dc2626;
+  border-right: 1px solid #2a3344;
+  flex-shrink: 0;
+}
+.tickerb__pill-text {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  font-weight: 600;
+}
+.tickerb__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #fffcf1;
+  animation: tickerb-pulse 1.4s infinite;
+  flex-shrink: 0;
+}
+.tickerb__dot--green {
+  background: #22c55e;
+}
+@keyframes tickerb-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.35; }
+}
+
+.tickerb__track {
+  flex: 1;
+  overflow: hidden;
+}
+.tickerb__scroller {
+  display: flex;
+  gap: 0;
+  white-space: nowrap;
+  animation: tickerb-scroll 60s linear infinite;
+}
+@keyframes tickerb-scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+.tickerb__track:hover .tickerb__scroller {
+  animation-play-state: paused;
+}
+
+.tickerb__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 18px;
+  height: 40px;
+  border-right: 1px solid #1a1f2c;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+}
+.tickerb__code {
+  font-size: 11px;
+  font-weight: 600;
+}
+.tickerb__score {
+  font-size: 13px;
+  font-weight: 700;
+  color: #fffcf1;
+}
+.tickerb__score--live {
+  color: #22c55e;
+}
+.tickerb__minute {
+  font-size: 10px;
+  color: #22c55e;
+  margin-left: 4px;
+}
+.tickerb__fin {
+  font-size: 9px;
+  color: #7a8195;
+  letter-spacing: 0.1em;
+  margin-left: 4px;
+}
+.tickerb__countdown {
+  font-size: 10px;
+  color: #fbbf24;
+  margin-left: 4px;
+}
+.tickerb__close {
+  width: 36px;
+  height: 40px;
+  min-height: 40px;
+  border: 0;
+  background: transparent;
+  color: #7a8195;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 20px;
+  line-height: 1;
+}
+.tickerb__close:hover {
+  color: #fffcf1;
+}
+.tickerb__close:focus-visible {
+  outline: 2px solid #fffcf1;
+  outline-offset: -4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tickerb__scroller { animation: none; }
+  .tickerb__dot     { animation: none; }
+}
+
+/* ────────────────────────────────────────────────────────────────
+ * TickerSlide — card autoplay con banderas grandes y dots.
+ * ──────────────────────────────────────────────────────────────── */
+
+.tickers {
+  padding: 18px;
+  position: relative;
+  overflow: hidden;
+}
+.tickers__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+}
+.tickers__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: var(--color-energy);
+  color: #fffcf1;
+  border-radius: 999px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+}
+.tickers__live-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: #fffcf1;
+  animation: tickerb-pulse 1.4s infinite;
+}
+.tickers__fase {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--color-foreground-subtle);
+}
+.tickers__grupo {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--color-foreground-subtle);
+}
+.tickers__partido {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 14px;
+}
+.tickers__lado {
+  text-align: center;
+}
+.tickers__nombre {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-top: 8px;
+}
+.tickers__centro {
+  text-align: center;
+  min-width: 80px;
+}
+.tickers__score {
+  font-size: 2.25rem;
+  line-height: 1;
+  color: var(--color-foreground);
+}
+.tickers__score--live {
+  color: var(--color-energy);
+}
+.tickers__sep {
+  color: var(--color-foreground-subtle);
+  margin: 0 6px;
+}
+.tickers__vs {
+  font-size: 1.125rem;
+  color: var(--color-foreground-muted);
+}
+.tickers__estado {
+  font-size: 10px;
+  color: var(--color-foreground-subtle);
+  margin-top: 6px;
+}
+.tickers__dots {
+  display: flex;
+  justify-content: center;
+  gap: 5px;
+  margin-top: 14px;
+}
+.tickers__dot {
+  width: 6px;
+  height: 6px;
+  min-height: 6px;
+  border-radius: 999px;
+  background: var(--color-border-strong);
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+.tickers__dot--active {
+  width: 18px;
+  background: var(--color-foreground);
+}
+.tickers__dot:focus-visible {
+  outline: 2px solid var(--color-foreground);
+  outline-offset: 3px;
+}
+
+/* ────────────────────────────────────────────────────────────────
+ * EncuestaCampeon — selección + podium top 3 + ranking completo.
+ * ──────────────────────────────────────────────────────────────── */
+
+.encuesta {
+  margin-top: 56px;
+}
+.encuesta--loading {
+  min-height: 280px;
+}
+.encuesta__skeleton {
+  height: 280px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    90deg,
+    var(--color-surface-alt) 0%,
+    var(--color-paper) 50%,
+    var(--color-surface-alt) 100%
+  );
+  background-size: 200% 100%;
+  animation: encuesta-shimmer 1.6s ease-in-out infinite;
+}
+@keyframes encuesta-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .encuesta__skeleton { animation: none; }
+}
+
+.encuesta__header {
+  max-width: 60ch;
+  margin-bottom: 24px;
+}
+.encuesta__eyebrow {
+  display: inline-block;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  color: var(--color-foreground-subtle);
+  margin-bottom: 8px;
+}
+.encuesta__titulo {
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  margin: 0 0 14px;
+}
+.encuesta__intro {
+  color: var(--color-foreground-muted);
+  font-size: 1rem;
+  line-height: 1.55;
+  margin: 0;
+}
+.encuesta__total {
+  font-size: 0.85em;
+  color: var(--color-foreground-subtle);
+}
+
+/* Grid de 48 selecciones para elegir voto */
+.encuesta__grid {
+  list-style: none;
+  padding: 0;
+  margin: 22px 0 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+.encuesta__opcion {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  min-height: 56px;
+  border: 1.5px solid var(--color-border);
+  background: var(--color-paper);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
+}
+.encuesta__opcion:hover {
+  border-color: var(--color-energy);
+  background: color-mix(in oklab, var(--color-energy), transparent 95%);
+}
+.encuesta__opcion:focus-visible {
+  outline: 3px solid color-mix(in oklab, var(--color-energy), transparent 60%);
+  outline-offset: 2px;
+}
+.encuesta__opcion:active {
+  transform: translateY(1px);
+}
+.encuesta__opcion-nombre {
+  font-size: 0.875rem;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+}
+
+@media (min-width: 480px)  { .encuesta__grid { grid-template-columns: repeat(3, 1fr); } }
+@media (min-width: 720px)  { .encuesta__grid { grid-template-columns: repeat(4, 1fr); } }
+@media (min-width: 1024px) { .encuesta__grid { grid-template-columns: repeat(6, 1fr); } }
+
+/* Podium top 3 */
+.encuesta__podium {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  align-items: flex-end;
+  gap: 12px;
+  margin-top: 22px;
+  padding: 18px 12px 0;
+  min-height: 280px;
+}
+.encuesta__paso {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 8px 18px;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border: 2px solid var(--color-border-strong);
+  background: var(--color-paper);
+  text-align: center;
+  /* La altura del podio se ajusta por posición vía CSS abajo. */
+}
+.encuesta__paso[data-pos='1'] {
+  border-color: #f59e0b;
+  background: linear-gradient(180deg, color-mix(in oklab, #facc15, transparent 85%), var(--color-paper) 60%);
+  min-height: 240px;
+  z-index: 2;
+}
+.encuesta__paso[data-pos='2'] {
+  border-color: #94a3b8;
+  background: linear-gradient(180deg, color-mix(in oklab, #cbd5e1, transparent 80%), var(--color-paper) 60%);
+  min-height: 200px;
+}
+.encuesta__paso[data-pos='3'] {
+  border-color: #c2410c;
+  background: linear-gradient(180deg, color-mix(in oklab, #f97316, transparent 85%), var(--color-paper) 60%);
+  min-height: 180px;
+}
+.encuesta__paso[data-mio='true']::after {
+  content: 'tu voto';
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%) rotate(-3deg);
+  background: var(--color-paper);
+  color: var(--color-handwritten);
+  font-family: var(--font-hand);
+  font-size: 18px;
+  padding: 0 10px;
+  border: 1px dashed var(--color-handwritten);
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.encuesta__paso-medalla {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+.encuesta__paso[data-pos='1'] .encuesta__paso-medalla { color: #f59e0b; font-size: 1.875rem; }
+.encuesta__paso[data-pos='2'] .encuesta__paso-medalla { color: #64748b; }
+.encuesta__paso[data-pos='3'] .encuesta__paso-medalla { color: #c2410c; }
+
+.encuesta__paso-bandera {
+  margin: 4px 0;
+}
+.encuesta__paso-nombre {
+  font-size: 0.95rem;
+  line-height: 1.1;
+  font-weight: 700;
+}
+.encuesta__paso[data-pos='1'] .encuesta__paso-nombre { font-size: 1.05rem; }
+.encuesta__paso-votos {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--color-foreground-muted);
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+
+/* Ranking 4 → 48 dentro de <details> */
+.encuesta__detalles {
+  margin-top: 28px;
+  border-top: 1px solid var(--color-border);
+  padding-top: 16px;
+}
+.encuesta__resumen {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--color-foreground-muted);
+  cursor: pointer;
+  text-transform: uppercase;
+  padding: 8px 0;
+  list-style: none;
+}
+.encuesta__resumen::-webkit-details-marker { display: none; }
+.encuesta__resumen::before {
+  content: '▸ ';
+  display: inline-block;
+  margin-right: 4px;
+  transition: transform var(--duration-fast);
+}
+.encuesta__detalles[open] .encuesta__resumen::before {
+  content: '▾ ';
+}
+
+.encuesta__lista {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: grid;
+  gap: 4px;
+}
+.encuesta__row {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) minmax(80px, 200px) 44px;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+}
+.encuesta__row[data-mio='true'] {
+  background: color-mix(in oklab, var(--color-energy), transparent 92%);
+}
+.encuesta__row-pos {
+  font-size: 11px;
+  color: var(--color-foreground-subtle);
+  text-align: center;
+}
+.encuesta__row-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.encuesta__row-nombre {
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.encuesta__row-mio {
+  font-size: 14px;
+  color: var(--color-handwritten);
+  padding: 0 6px;
+  border: 1px dashed var(--color-handwritten);
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.encuesta__row-bar {
+  position: relative;
+  height: 6px;
+  background: var(--color-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.encuesta__row-bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--color-energy);
+  border-radius: 999px;
+  transition: width var(--duration-base) var(--ease-out);
+}
+.encuesta__row[data-mio='true'] .encuesta__row-bar-fill {
+  background: var(--color-secondary);
+}
+.encuesta__row-pct {
+  font-size: 11px;
+  color: var(--color-foreground-muted);
+  text-align: right;
+}
+
+.encuesta__cambiar {
+  margin-top: 24px;
+}


### PR DESCRIPTION
## Resumen

Reemplaza el listado genérico de la categoría `mundial-2026` por una página educativa para niños 4-12 años, lista para encender la cara "live" (resultados, tablas, goleadores) cuando empiece el torneo el 11-jun-2026 sin tocar código.

### Pre-torneo (visible ya)

- **Hero** con dorsal 05 rojo, countdown a la inauguración y 4 stats cards.
- **¿Qué es el Mundial?** — 3 cards (48 selecciones, cada 4 años, 3 anfitriones).
- **Cómo funciona** — embudo 48→32→16→8→4→2→1 con descripción para niños.
- **Los 12 grupos** — banderas + nombres de las 48 selecciones. ⚠ Datos **provisionales**, verificar contra sorteo oficial FIFA antes de publicar.
- **Calendario** — timeline con los 8 hitos del torneo, marcando próximo y pasados.
- **Historia curiosa** — 5 últimos campeones + 5 datos curiosos.
- **Encuesta "¿quién crees que ganará?"** — vista A (grid 48 selecciones) → vista B (podium top 3 estilo olímpico oro/plata/bronce + ranking 4-48 con barras de % + botón cambiar voto). Voto en localStorage, counts agregados mock (sustituibles por endpoint en Fase 6).
- **Artículos editoriales** — grid de los 3 artículos existentes de la categoría.

### Listos para encender (construidos, gated por `isMundialActive()`)

`PartidoRow`, `TablaGrupo` (PJ/G/E/P/GF/GC/PTS, top 2 verde), `Goleadores` (top N con podium), `TickerCuaderno`, `TickerBolsa` (scroll horizontal 60s + `prefers-reduced-motion`), `TickerSlide` (autoplay 4.5s con dots).

### Calidad

- Lighthouse local: **Performance 92 · A11y 100 · SEO 100 · Best Practices 100** · LCP 2.9s · CLS 0.017.
- Schema.org: **FAQPage** (6 preguntas, candidato a featured snippets) + **SportsEvent** + **BreadcrumbList**.
- 0 errores typecheck, 0 warnings.
- `preconnect` a `flagcdn.com` para reducir TLS de las 48 banderas.

### Cambios estructurales

- `src/pages/[categoria]/index.astro` excluye `mundial-2026` para que la nueva página estática gane sin pisar el resto de categorías. Los 3 artículos siguen accesibles en `/mundial-2026/<slug>/`.
- `Tournament` tipado en `src/lib/mundial/dates.ts` para reutilizar en Mundial femenino 2027 sin duplicar fechas hardcoded.

## Test plan

- [ ] Visitar `/mundial-2026/` y revisar las 7 secciones en desktop y mobile.
- [ ] Verificar el countdown del hero ("faltan X días para la inauguración").
- [ ] Probar la encuesta: votar una selección → comprobar podium → recargar (voto persiste) → cambiar voto.
- [ ] Confirmar que `/mundial-2026/calendario-mundial-2026-ninos/`, `/mundial-2026/mejores-selecciones-mundial-ninos/` y `/mundial-2026/mundial-2026-explicado-ninos/` siguen funcionando.
- [ ] **Verificar contra el sorteo oficial FIFA los 12 grupos en `src/lib/mundial/grupos.ts`** antes de merge final.
- [ ] Probar fallback de banderas: bloquear `flagcdn.com` en devtools → debería verse el chip de color con código ISO3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)