### PR TITLE
fix(mundial): reemplazar grupos provisionales por sorteo oficial FIFA

### DIFF
--- a/src/components/mundial/EncuestaCampeon.tsx
+++ b/src/components/mundial/EncuestaCampeon.tsx
@@ -27,12 +27,18 @@ const LS_KEY = 'mg.mundial.encuesta-campeon';
  * + países anfitriones. Sustituir por fetch real en Fase 6.
  */
 const INITIAL_COUNTS: Record<string, number> = {
-  ARG: 187, BRA: 152, FRA: 124, ESP: 118, ENG: 96, GER: 84, POR: 71, NED: 58,
-  MEX: 54, USA: 47, ITA: 42, URU: 38, COL: 35, BEL: 31, CRO: 28, JPN: 24,
-  MAR: 22, KOR: 19, CAN: 18, SUI: 16, DEN: 14, AUS: 13, SEN: 11, NOR: 10,
-  POL: 9,  AUT: 8,  ECU: 8,  TUR: 7, EGY: 7, NGA: 6, IRN: 6, KSA: 5,
-  PAR: 5,  CIV: 4,  GHA: 4,  ALG: 4, TUN: 3, CMR: 3, JAM: 3, QAT: 3,
-  CRC: 2,  PAN: 2,  HON: 2,  HUN: 2, SVK: 2, UZB: 1, NZL: 1, IRQ: 1,
+  // Favoritos absolutos
+  ARG: 195, BRA: 145, FRA: 105, ESP: 90,
+  // Favoritos
+  ENG: 80, GER: 70, POR: 65, NED: 55,
+  // Anfitriones + competitivos
+  MEX: 50, USA: 45, BEL: 28, URU: 28, CRO: 25, COL: 24,
+  // Competitivos
+  JPN: 22, KOR: 18, MAR: 15, SEN: 14, ECU: 12, AUS: 11, SUI: 10, NOR: 8,
+  // Resto del torneo (las 48 selecciones cubiertas)
+  CAN: 12, RSA: 8, AUT: 7, TUR: 7, EGY: 7, SWE: 7, CIV: 6, GHA: 6, ALG: 6,
+  CZE: 5, SCO: 5, IRN: 5, TUN: 4, KSA: 4, PAR: 4, IRQ: 4, QAT: 4, UZB: 4,
+  JOR: 3, BIH: 3, HAI: 3, CUW: 3, CPV: 3, COD: 3, PAN: 3, NZL: 2,
 };
 
 function loadVote(): Vote | null {

--- a/src/lib/mundial/grupos.ts
+++ b/src/lib/mundial/grupos.ts
@@ -1,32 +1,27 @@
 import type { Grupo } from './types';
 
 /**
- * ⚠ DATOS PROVISIONALES — sorteo oficial FIFA del 5 dic 2025.
+ * Grupos OFICIALES del Mundial 2026 — sorteo FIFA del 5 dic 2025 en
+ * Washington D.C., con los repechajes de UEFA e Intercontinental ya resueltos
+ * (marzo 2026). Verificado contra dos fuentes independientes
+ * (mundial-2026.com.mx y alairelibre.cl) el 16 may 2026.
  *
- * Esta es una distribución plausible basada en el sistema de bombos
- * (anfitriones + ranking FIFA), NO el sorteo final confirmado al 100%.
- * Antes del 11 jun 2026, verificar grupo por grupo contra
- * https://www.fifa.com/fifaplus/es/tournaments/mens/worldcup/canadamexicousa2026
- * y corregir aquí. El resto del código no depende del orden ni de la
- * pertenencia — solo de las claves ISO3 (que están todas en
- * `selecciones.ts`).
- *
- * Formato 2026: 12 grupos × 4 selecciones = 48 equipos. Pasan a la fase
+ * Formato 2026: 12 grupos × 4 selecciones = 48 equipos. Avanzan a la fase
  * final 32: los 2 primeros de cada grupo (24) + los 8 mejores terceros.
  */
 export const GRUPOS: readonly Grupo[] = [
-  { letra: 'A', equipos: ['MEX', 'POR', 'POL', 'NZL'] }, // anfitrión 1: México
-  { letra: 'B', equipos: ['CAN', 'BEL', 'KOR', 'CRC'] }, // anfitrión 2: Canadá
-  { letra: 'C', equipos: ['USA', 'NED', 'AUS', 'PAN'] }, // anfitrión 3: USA
-  { letra: 'D', equipos: ['ARG', 'CRO', 'MAR', 'JAM'] },
-  { letra: 'E', equipos: ['BRA', 'ENG', 'JPN', 'ECU'] },
-  { letra: 'F', equipos: ['ESP', 'GER', 'IRN', 'PAR'] },
-  { letra: 'G', equipos: ['FRA', 'ITA', 'EGY', 'CIV'] },
-  { letra: 'H', equipos: ['HUN', 'SUI', 'SEN', 'UZB'] },
-  { letra: 'I', equipos: ['COL', 'DEN', 'NGA', 'QAT'] },
-  { letra: 'J', equipos: ['URU', 'AUT', 'GHA', 'KSA'] },
-  { letra: 'K', equipos: ['NOR', 'TUR', 'CMR', 'JOR'] },
-  { letra: 'L', equipos: ['SVK', 'TUN', 'ALG', 'HON'] },
+  { letra: 'A', equipos: ['MEX', 'RSA', 'KOR', 'CZE'] }, // anfitrión 1: México
+  { letra: 'B', equipos: ['CAN', 'BIH', 'SUI', 'QAT'] }, // anfitrión 2: Canadá
+  { letra: 'C', equipos: ['BRA', 'MAR', 'SCO', 'HAI'] },
+  { letra: 'D', equipos: ['USA', 'PAR', 'AUS', 'TUR'] }, // anfitrión 3: EE.UU.
+  { letra: 'E', equipos: ['GER', 'CUW', 'CIV', 'ECU'] },
+  { letra: 'F', equipos: ['NED', 'JPN', 'SWE', 'TUN'] },
+  { letra: 'G', equipos: ['BEL', 'EGY', 'IRN', 'NZL'] },
+  { letra: 'H', equipos: ['ESP', 'CPV', 'KSA', 'URU'] },
+  { letra: 'I', equipos: ['FRA', 'SEN', 'IRQ', 'NOR'] },
+  { letra: 'J', equipos: ['ARG', 'ALG', 'AUT', 'JOR'] },
+  { letra: 'K', equipos: ['POR', 'COD', 'UZB', 'COL'] },
+  { letra: 'L', equipos: ['ENG', 'CRO', 'GHA', 'PAN'] },
 ] as const;
 
 /** Lookup por letra. */

--- a/src/lib/mundial/selecciones.ts
+++ b/src/lib/mundial/selecciones.ts
@@ -16,7 +16,7 @@ export const ISO3_TO_ISO2: Readonly<Record<string, string>> = {
   ESP: 'es', FRA: 'fr', ENG: 'gb-eng', GER: 'de', ITA: 'it', NED: 'nl', POR: 'pt',
   BEL: 'be', CRO: 'hr', SUI: 'ch', DEN: 'dk', AUT: 'at', POL: 'pl', NOR: 'no',
   CZE: 'cz', TUR: 'tr', SWE: 'se', SRB: 'rs', UKR: 'ua', SCO: 'gb-sct', HUN: 'hu',
-  WAL: 'gb-wls', SVK: 'sk',
+  WAL: 'gb-wls', SVK: 'sk', BIH: 'ba',
   // CONMEBOL
   ARG: 'ar', BRA: 'br', URU: 'uy', COL: 'co', ECU: 'ec', PAR: 'py', VEN: 've', BOL: 'bo',
   // AFC
@@ -24,9 +24,9 @@ export const ISO3_TO_ISO2: Readonly<Record<string, string>> = {
   UAE: 'ae', UZB: 'uz', JOR: 'jo',
   // CAF
   MAR: 'ma', SEN: 'sn', EGY: 'eg', NGA: 'ng', ALG: 'dz', TUN: 'tn', CMR: 'cm',
-  GHA: 'gh', CIV: 'ci', RSA: 'za', MLI: 'ml',
+  GHA: 'gh', CIV: 'ci', RSA: 'za', MLI: 'ml', CPV: 'cv', COD: 'cd',
   // CONCACAF
-  CRC: 'cr', PAN: 'pa', JAM: 'jm', HON: 'hn',
+  CRC: 'cr', PAN: 'pa', JAM: 'jm', HON: 'hn', HAI: 'ht', CUW: 'cw',
   // OFC
   NZL: 'nz',
 };
@@ -69,6 +69,7 @@ export const SELECCIONES: Readonly<Record<string, Team>> = {
   HUN: { code: 'HUN', iso2: 'hu',     nombre: 'Hungría',          color: '#477050', confederation: 'UEFA' },
   WAL: { code: 'WAL', iso2: 'gb-wls', nombre: 'Gales',            color: '#d30731', confederation: 'UEFA' },
   SVK: { code: 'SVK', iso2: 'sk',     nombre: 'Eslovaquia',       color: '#0b4ea2', confederation: 'UEFA' },
+  BIH: { code: 'BIH', iso2: 'ba',     nombre: 'Bosnia y Herzegovina', color: '#002395', confederation: 'UEFA' },
 
   // ─── CONMEBOL ───────────────────────────────────────────────
   ARG: { code: 'ARG', iso2: 'ar', nombre: 'Argentina',  color: '#74acdf', confederation: 'CONMEBOL' },
@@ -104,12 +105,16 @@ export const SELECCIONES: Readonly<Record<string, Team>> = {
   CIV: { code: 'CIV', iso2: 'ci', nombre: 'Costa de Marfil', color: '#ff8200', confederation: 'CAF' },
   RSA: { code: 'RSA', iso2: 'za', nombre: 'Sudáfrica',     color: '#007a4d', confederation: 'CAF' },
   MLI: { code: 'MLI', iso2: 'ml', nombre: 'Malí',          color: '#fcd116', confederation: 'CAF' },
+  CPV: { code: 'CPV', iso2: 'cv', nombre: 'Cabo Verde',    color: '#003893', confederation: 'CAF' },
+  COD: { code: 'COD', iso2: 'cd', nombre: 'RD Congo',      color: '#007fff', confederation: 'CAF' },
 
   // ─── CONCACAF (no anfitriones) ──────────────────────────────
   CRC: { code: 'CRC', iso2: 'cr', nombre: 'Costa Rica',     color: '#002b7f', confederation: 'CONCACAF' },
   PAN: { code: 'PAN', iso2: 'pa', nombre: 'Panamá',         color: '#005aa7', confederation: 'CONCACAF' },
   JAM: { code: 'JAM', iso2: 'jm', nombre: 'Jamaica',        color: '#009b3a', confederation: 'CONCACAF' },
   HON: { code: 'HON', iso2: 'hn', nombre: 'Honduras',       color: '#0073cf', confederation: 'CONCACAF' },
+  HAI: { code: 'HAI', iso2: 'ht', nombre: 'Haití',          color: '#00209f', confederation: 'CONCACAF' },
+  CUW: { code: 'CUW', iso2: 'cw', nombre: 'Curazao',        color: '#002b7f', confederation: 'CONCACAF' },
 
   // ─── OFC ────────────────────────────────────────────────────
   NZL: { code: 'NZL', iso2: 'nz', nombre: 'Nueva Zelanda',  color: '#012169', confederation: 'OFC' },


### PR DESCRIPTION
## Resumen

Los 12 grupos en \`src/lib/mundial/grupos.ts\` eran **provisionales** (mockup del handoff). Esta PR los reemplaza por el **sorteo oficial FIFA del 5 dic 2025** en Washington D.C., con los repechajes ya resueltos.

Verificado contra dos fuentes independientes:
- [mundial-2026.com.mx/grupos/](https://mundial-2026.com.mx/grupos/)
- [alairelibre.cl/mundial-2026-equipos-grupos](https://www.alairelibre.cl/futbol/mundial/mundial-2026-equipos-grupos-fixture-sede/)

## Cambios destacables vs el provisional

- **Italia y Polonia** se quedaron fuera. Suecia, Turquía y Bosnia entraron por repechaje UEFA.
- **Curazao, Cabo Verde, Haití y RD Congo** clasifican por primera vez a un Mundial → añadidos al catálogo \`SELECCIONES\` con sus ISO3/2 y colores brand.
- **México (anfitrión)** queda en Grupo A con Sudáfrica, Corea del Sur y Chequia. Inauguración 11-jun México vs Sudáfrica en el Azteca.
- **España** en Grupo H con Cabo Verde, Arabia Saudí y Uruguay.
- **Argentina** en Grupo J con Argelia, Austria y Jordania.

## Otros archivos tocados

- \`src/lib/mundial/selecciones.ts\` — 5 nuevas entradas (BIH, HAI, CUW, CPV, COD) con metadata y mapeo ISO3→ISO2.
- \`src/components/mundial/EncuestaCampeon.tsx\` — \`INITIAL_COUNTS\` actualizado para cubrir las 48 selecciones reales (~1240 votos mock). Total bajó ligeramente porque algunas que tenían votos (Italia, Polonia, Nigeria…) ya no están.

## Test plan

- [ ] Visitar \`/mundial-2026/\` → sección "Los 12 grupos" debe mostrar el sorteo oficial.
- [ ] Encuesta: las 48 banderas mostradas deben ser las del sorteo oficial (no aparece Italia, sí aparece Bosnia).
- [ ] Verificar que las 4 nuevas banderas (Bosnia, Curazao, Cabo Verde, Haití, RD Congo) cargan desde flagcdn.com.
- [ ] Build: 0 errors, 56 páginas (sin cambio en número de rutas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)