### PR TITLE
feat(encuesta): backend Cloudflare Worker + KV para agregar votos reales

### DIFF
--- a/src/components/mundial/EncuestaCampeon.tsx
+++ b/src/components/mundial/EncuestaCampeon.tsx
@@ -1,19 +1,21 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import { SELECCIONES } from '@/lib/mundial/selecciones';
 import { SELECCIONES_DEL_TORNEO } from '@/lib/mundial/grupos';
+import { ENCUESTA_API_URL } from '@/consts';
 import type { Vote } from '@/lib/mundial/types';
 import { Flag } from './FlagPreact';
 
 /**
  * Encuesta "¿quién crees que ganará el Mundial 2026?".
  *
- * Estado:
- * - Cada usuario vota UNA vez (cambiable). Persistido en localStorage.
- * - Los counts agregados son MOCK por ahora — distribución plausible que
- *   favorece a las grandes potencias. Cuando exista backend (Fase 6),
- *   sustituir `INITIAL_COUNTS` por un fetch a `/api/encuesta-campeon`.
- * - El voto del usuario se suma client-side a los counts visibles para que
- *   "su" voto se refleje en el podium inmediatamente.
+ * Modo online (recomendado): si `ENCUESTA_API_URL` está configurada, los
+ * counts agregados vienen del Worker `workers/encuesta-mundial/`. Los votos
+ * se suman en KV y todos los usuarios ven el mismo podium en tiempo real.
+ *
+ * Modo offline (fallback): si la API no responde o no está configurada,
+ * la encuesta sigue funcionando contra `INITIAL_COUNTS` (mock local) y
+ * localStorage. El usuario ve su voto reflejado en SU vista, pero no se
+ * agrega entre dispositivos.
  *
  * Vista A (sin voto): grid con las 48 selecciones, clic para elegir.
  * Vista B (con voto): podium top 3 + ranking completo con barras + "cambiar voto".
@@ -22,9 +24,9 @@ import { Flag } from './FlagPreact';
 const LS_KEY = 'mg.mundial.encuesta-campeon';
 
 /**
- * Mock de votos pre-cargados — escenario realista que el usuario verá la primera
- * vez que entre. Total ~1200 votos. Distribución basada en favoritismo histórico
- * + países anfitriones. Sustituir por fetch real en Fase 6.
+ * Seed inicial — mismo objeto debe estar en `workers/encuesta-mundial/src/index.ts`.
+ * Se usa cuando el backend no responde (modo offline) o como base inicial
+ * antes del primer fetch. Distribución por favoritismo histórico + anfitriones.
  */
 const INITIAL_COUNTS: Record<string, number> = {
   // Favoritos absolutos
@@ -40,6 +42,38 @@ const INITIAL_COUNTS: Record<string, number> = {
   CZE: 5, SCO: 5, IRN: 5, TUN: 4, KSA: 4, PAR: 4, IRQ: 4, QAT: 4, UZB: 4,
   JOR: 3, BIH: 3, HAI: 3, CUW: 3, CPV: 3, COD: 3, PAN: 3, NZL: 2,
 };
+
+type CountsBy = Record<string, number>;
+
+/** GET counts del backend. Devuelve null si la API no está configurada o falla. */
+async function fetchCounts(): Promise<CountsBy | null> {
+  if (!ENCUESTA_API_URL) return null;
+  try {
+    const r = await fetch(ENCUESTA_API_URL, { method: 'GET' });
+    if (!r.ok) return null;
+    const data = (await r.json()) as { counts?: CountsBy };
+    return data.counts ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** POST voto al backend. Devuelve los counts actualizados o null si falla. */
+async function postVote(team: string): Promise<CountsBy | null> {
+  if (!ENCUESTA_API_URL) return null;
+  try {
+    const r = await fetch(ENCUESTA_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ team }),
+    });
+    if (!r.ok) return null;
+    const data = (await r.json()) as { counts?: CountsBy };
+    return data.counts ?? null;
+  } catch {
+    return null;
+  }
+}
 
 function loadVote(): Vote | null {
   try {
@@ -65,33 +99,58 @@ function saveVote(v: Vote | null) {
 export function EncuestaCampeon() {
   const [voto, setVoto] = useState<Vote | null>(null);
   const [hidratado, setHidratado] = useState(false);
+  /**
+   * Counts agregados desde el backend. `null` mientras no hayan llegado del
+   * servidor o si la API falla. El render combina estos con el seed local
+   * y con el voto del usuario para reflejar su elección al instante.
+   */
+  const [serverCounts, setServerCounts] = useState<CountsBy | null>(null);
 
-  // Cargar voto desde localStorage en mount (no en SSR — el componente es client-only).
+  // Cargar voto local + fetch inicial de counts. Side effects client-only.
   useEffect(() => {
     setVoto(loadVote());
     setHidratado(true);
+    void fetchCounts().then(setServerCounts);
   }, []);
 
-  function elegir(team: string) {
+  async function elegir(team: string) {
     const v: Vote = { team, at: new Date().toISOString() };
     setVoto(v);
     saveVote(v);
+    // POST en background: si funciona, refrescamos counts del servidor.
+    // Si falla, el voto sigue guardado localmente — el podium se calcula
+    // con seed + voto, así que la UX no se rompe.
+    const fresh = await postVote(team);
+    if (fresh) setServerCounts(fresh);
   }
 
   function cambiar() {
     setVoto(null);
     saveVote(null);
+    // No mandamos POST para "revertir voto" — el siguiente voto del usuario
+    // hará que el backend decremente el anterior y sume el nuevo en una
+    // sola operación. Mientras tanto su counter del antiguo queda intacto
+    // en el servidor (visible para otros), lo cual es aceptable.
   }
 
-  // Counts agregados = mock + 1 al voto del usuario.
+  /**
+   * Counts a mostrar: prioridad serverCounts (si hay) sobre INITIAL_COUNTS.
+   * Si el voto del usuario aún no se ha confirmado por el backend (POST en
+   * vuelo o falló), añadimos +1 client-side al equipo elegido — pero NO si
+   * el server ya refleja el voto (evita doble conteo cuando el POST vuelve).
+   */
   const counts = useMemo(() => {
+    const base = serverCounts ?? null;
     const c: Record<string, number> = {};
     for (const code of SELECCIONES_DEL_TORNEO) {
-      c[code] = INITIAL_COUNTS[code] ?? 0;
+      c[code] = base ? (base[code] ?? 0) : (INITIAL_COUNTS[code] ?? 0);
     }
-    if (voto) c[voto.team] = (c[voto.team] ?? 0) + 1;
+    if (voto && !base) {
+      // Sin server (offline o pending): sumar voto local al podium.
+      c[voto.team] = (c[voto.team] ?? 0) + 1;
+    }
     return c;
-  }, [voto]);
+  }, [voto, serverCounts]);
 
   const ranking = useMemo(() => {
     return SELECCIONES_DEL_TORNEO
@@ -116,7 +175,7 @@ export function EncuestaCampeon() {
 
 // ───────────────────────────── Vista A: sin voto ─────────────────────────────
 
-function SinVoto({ onElegir }: { onElegir: (code: string) => void }) {
+function SinVoto({ onElegir }: { onElegir: (code: string) => void | Promise<void> }) {
   return (
     <section class="encuesta encuesta--sin-voto" aria-labelledby="enc-titulo">
       <header class="encuesta__header">

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,6 +3,11 @@ export const GA_ID = 'G-705L75RTFB';
 export const ADSENSE_CLIENT = import.meta.env.PUBLIC_ADSENSE_CLIENT ?? '';
 export const AMAZON_TAG = import.meta.env.PUBLIC_AMAZON_TAG ?? '';
 
+// URL del Worker de Cloudflare que aloja la encuesta del Mundial.
+// Si está vacía, la encuesta cae al modo offline (localStorage + mock counts).
+// Ver workers/encuesta-mundial/README.md para deploy + cómo obtener la URL.
+export const ENCUESTA_API_URL = import.meta.env.PUBLIC_ENCUESTA_API_URL ?? '';
+
 export function amazonUrl(asin: string): string {
   const base = `https://www.amazon.es/dp/${asin}`;
   return AMAZON_TAG ? `${base}?tag=${AMAZON_TAG}` : base;

--- a/workers/encuesta-mundial/README.md
+++ b/workers/encuesta-mundial/README.md
@@ -1,0 +1,107 @@
+# encuesta-mundial · Worker
+
+Backend de la encuesta "¿quién crees que ganará el Mundial 2026?" que vive
+en `src/components/mundial/EncuestaCampeon.tsx`. Cloudflare Worker + KV.
+
+## Endpoints
+
+| Método | Body | Respuesta |
+|---|---|---|
+| `GET /` | — | `{ counts: { ISO3: número }, total: número }` |
+| `POST /` | `{ "team": "ISO3" }` | `{ changed: bool, vote: ISO3, counts, total }` |
+| `OPTIONS /` | — | CORS preflight |
+
+Solo acepta los 48 ISO3 del torneo (lista en `src/index.ts`). Cualquier
+otro código devuelve `400`.
+
+## Anti-spam
+
+Hash `SHA-256(IP|User-Agent)` truncado a 16 bytes. Un voto por dispositivo.
+Si vota de nuevo, el contador del equipo anterior se decrementa y el del
+nuevo se incrementa (cambio de pronóstico). TTL del registro de votante:
+`VOTER_TTL_DAYS` (default 90 días).
+
+## Setup inicial — UNA VEZ
+
+```bash
+cd workers/encuesta-mundial
+pnpm install
+
+# Login en Cloudflare (si no lo estás)
+pnpm exec wrangler login
+
+# Crear el KV namespace y anotar el `id` devuelto
+pnpm exec wrangler kv namespace create ENCUESTA_MUNDIAL
+# Salida ejemplo:
+#   [[kv_namespaces]]
+#   binding = "ENCUESTA_MUNDIAL"
+#   id = "abc123def456..."
+
+# Pegar el `id` en wrangler.toml sustituyendo `REEMPLAZAR_TRAS_CREAR_KV`
+```
+
+## Deploy
+
+```bash
+pnpm deploy
+# Wrangler imprime la URL del worker, p.ej.:
+#   https://minigolclub-encuesta-mundial.<tu-subdominio>.workers.dev/
+```
+
+## Configurar el frontend
+
+Añadir a `.env` (local dev) o a las variables de entorno del despliegue de
+Astro la URL del Worker desplegado:
+
+```
+PUBLIC_ENCUESTA_API_URL=https://minigolclub-encuesta-mundial.<tu-subdominio>.workers.dev
+```
+
+Si la variable está vacía o el Worker no responde, el componente cae en
+modo **offline** (localStorage + seed counts mock). Ningún breaking change.
+
+### Opcional: dominio propio
+
+Para evitar CORS y servir desde `minigolclub.com/api/encuesta-campeon`:
+
+1. Descomentar el bloque `[[routes]]` en `wrangler.toml`.
+2. Re-deploy.
+3. Cambiar `PUBLIC_ENCUESTA_API_URL` a `https://minigolclub.com/api/encuesta-campeon`.
+
+## Verificar
+
+```bash
+# GET counts (debería devolver los seed counts hasta el primer voto real)
+curl https://minigolclub-encuesta-mundial.<sub>.workers.dev/
+
+# POST voto
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"team":"ARG"}' \
+  https://minigolclub-encuesta-mundial.<sub>.workers.dev/
+```
+
+## Mantener en sync
+
+Tres constantes deben coincidir entre Worker y frontend. Si cambias una,
+cambia las otras:
+
+| Worker | Frontend |
+|---|---|
+| `TOURNAMENT_TEAMS` en `src/index.ts` | `SELECCIONES_DEL_TORNEO` (derivado de `src/lib/mundial/grupos.ts`) |
+| `INITIAL_COUNTS` en `src/index.ts` | `INITIAL_COUNTS` en `src/components/mundial/EncuestaCampeon.tsx` |
+
+## Decisiones de diseño
+
+- **KV en vez de Durable Objects:** simplicidad. KV no es atómico para
+  read-then-write, así que dos votos simultáneos al mismo equipo pueden
+  perder uno. Para nuestro volumen esperado (~cientos/día) es aceptable.
+  Migrar a DO si se vuelve viral.
+- **Seed hardcoded en KV-less reads:** si KV no tiene una key, el GET
+  devuelve el valor de `INITIAL_COUNTS`. Esto evita "0 votos para todos"
+  cuando se despliega y arranca la encuesta. Tras el primer voto a un
+  país, KV manda.
+- **Sin auth, sin captcha:** es una encuesta lúdica de fútbol infantil.
+  Bypass posible con VPN/incognito — coste-beneficio claramente a favor
+  de la simplicidad.
+- **CORS por allowlist** — no `*`. Si añades dominios (preview deploys
+  con .pages.dev, etc.) los listas en `ALLOWED_ORIGINS` en `wrangler.toml`.

--- a/workers/encuesta-mundial/package.json
+++ b/workers/encuesta-mundial/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "minigolclub-encuesta-mundial",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250419.0",
+    "typescript": "^6.0.3",
+    "wrangler": "^4.42.0"
+  }
+}

--- a/workers/encuesta-mundial/pnpm-lock.yaml
+++ b/workers/encuesta-mundial/pnpm-lock.yaml
@@ -1,0 +1,888 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250419.0
+        version: 4.20260516.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      wrangler:
+        specifier: ^4.42.0
+        version: 4.92.0(@cloudflare/workers-types@4.20260516.1)
+
+packages:
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
+    resolution: {integrity: sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
+    resolution: {integrity: sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260515.1':
+    resolution: {integrity: sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
+    resolution: {integrity: sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260515.1':
+    resolution: {integrity: sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260516.1':
+    resolution: {integrity: sha512-aPckyZSPQXhOo+nSIvGLtXVl9M2qmf2GwFZYmvut9z47F1XTjHYcaYpI9/BvxrI+Q5l99UtXZU4bmQtX10JG+w==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  miniflare@4.20260515.0:
+    resolution: {integrity: sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  workerd@1.20260515.1:
+    resolution: {integrity: sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.92.0:
+    resolution: {integrity: sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260515.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+snapshots:
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260515.1
+
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260515.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260515.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260516.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
+
+  blake3-wasm@2.1.5: {}
+
+  cookie@1.1.1: {}
+
+  detect-libc@2.1.2: {}
+
+  error-stack-parser-es@1.0.5: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  kleur@4.1.5: {}
+
+  miniflare@4.20260515.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260515.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
+
+  semver@7.8.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.0
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  supports-color@10.2.2: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.3: {}
+
+  undici@7.24.8: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  workerd@1.20260515.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260515.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260515.1
+      '@cloudflare/workerd-linux-64': 1.20260515.1
+      '@cloudflare/workerd-linux-arm64': 1.20260515.1
+      '@cloudflare/workerd-windows-64': 1.20260515.1
+
+  wrangler@4.92.0(@cloudflare/workers-types@4.20260516.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260515.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260515.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260516.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ws@8.18.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3

--- a/workers/encuesta-mundial/src/index.ts
+++ b/workers/encuesta-mundial/src/index.ts
@@ -1,0 +1,196 @@
+/**
+ * encuesta-mundial Worker
+ *
+ * Backend de la encuesta "¿quién crees que ganará el Mundial 2026?".
+ *
+ * Endpoints:
+ *   GET  /            → { counts: { ISO3: número }, total: número }
+ *   POST /            body { team: "ISO3" } → registra voto y devuelve counts actualizados
+ *   OPTIONS /         → CORS preflight
+ *
+ * Storage (KV namespace `ENCUESTA_MUNDIAL`):
+ *   count:<ISO3>     → string, contador de votos para esa selección
+ *   voter:<hash>     → string ISO3, registro del voto de un dispositivo (TTL configurable)
+ *
+ * Anti-spam:
+ *   - Un voto por dispositivo (hash de IP + User-Agent). Si vota otra vez,
+ *     se decrementa el contador del anterior y se incrementa el nuevo.
+ *   - Sin auth, sin captcha. Bypass posible con VPN/incognito — aceptable
+ *     para una encuesta lúdica de fútbol infantil.
+ *
+ * Race conditions:
+ *   Cloudflare KV no es atómico. Reads-then-writes pueden colisionar.
+ *   Para nuestro volumen esperado (~cientos de votos/día) es aceptable.
+ *   Si en algún momento la encuesta se vuelve viral, migrar a Durable Objects.
+ */
+
+interface Env {
+  ENCUESTA_MUNDIAL: KVNamespace;
+  ALLOWED_ORIGINS: string;
+  VOTER_TTL_DAYS: string;
+}
+
+/**
+ * Las 48 selecciones del Mundial 2026 — debe coincidir EXACTAMENTE con
+ * `src/lib/mundial/grupos.ts` (SELECCIONES_DEL_TORNEO).
+ * Si cambia el sorteo, actualizar también aquí. Worker rechaza votos por
+ * códigos fuera de esta lista para evitar polución de KV.
+ */
+const TOURNAMENT_TEAMS: ReadonlySet<string> = new Set([
+  'MEX', 'RSA', 'KOR', 'CZE',
+  'CAN', 'BIH', 'SUI', 'QAT',
+  'BRA', 'MAR', 'SCO', 'HAI',
+  'USA', 'PAR', 'AUS', 'TUR',
+  'GER', 'CUW', 'CIV', 'ECU',
+  'NED', 'JPN', 'SWE', 'TUN',
+  'BEL', 'EGY', 'IRN', 'NZL',
+  'ESP', 'CPV', 'KSA', 'URU',
+  'FRA', 'SEN', 'IRQ', 'NOR',
+  'ARG', 'ALG', 'AUT', 'JOR',
+  'POR', 'COD', 'UZB', 'COL',
+  'ENG', 'CRO', 'GHA', 'PAN',
+]);
+
+/**
+ * Seed inicial. Debe coincidir con `INITIAL_COUNTS` de
+ * `src/components/mundial/EncuestaCampeon.tsx`. Se usa solo si KV está vacía
+ * para esa clave — permite que la encuesta arranque con un escenario realista
+ * en lugar de "0 votos para todos". Tras el primer voto real de un país, el
+ * KV manda y el seed deja de aplicarse a ese país.
+ */
+const INITIAL_COUNTS: Readonly<Record<string, number>> = {
+  ARG: 195, BRA: 145, FRA: 105, ESP: 90,
+  ENG: 80, GER: 70, POR: 65, NED: 55,
+  MEX: 50, USA: 45, BEL: 28, URU: 28, CRO: 25, COL: 24,
+  JPN: 22, KOR: 18, MAR: 15, SEN: 14, ECU: 12, AUS: 11, SUI: 10, NOR: 8,
+  CAN: 12, RSA: 8, AUT: 7, TUR: 7, EGY: 7, SWE: 7, CIV: 6, GHA: 6, ALG: 6,
+  CZE: 5, SCO: 5, IRN: 5, TUN: 4, KSA: 4, PAR: 4, IRQ: 4, QAT: 4, UZB: 4,
+  JOR: 3, BIH: 3, HAI: 3, CUW: 3, CPV: 3, COD: 3, PAN: 3, NZL: 2,
+};
+
+// ─── CORS ─────────────────────────────────────────────────────────────────
+
+function corsHeaders(origin: string | null, env: Env): Record<string, string> {
+  const allowed = env.ALLOWED_ORIGINS.split(',').map(o => o.trim());
+  const allowOrigin = origin && allowed.includes(origin) ? origin : allowed[0] ?? '*';
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+    'Vary': 'Origin',
+  };
+}
+
+function json(body: unknown, init: ResponseInit & { headers: Record<string, string> }): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { ...init.headers, 'Content-Type': 'application/json; charset=utf-8' },
+  });
+}
+
+// ─── Voter ID (hash IP + UA) ──────────────────────────────────────────────
+
+async function hashVoterId(req: Request): Promise<string> {
+  const ip = req.headers.get('cf-connecting-ip') ?? 'unknown-ip';
+  const ua = req.headers.get('user-agent') ?? 'unknown-ua';
+  const data = new TextEncoder().encode(`${ip}|${ua}`);
+  const buf = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 32);
+}
+
+// ─── Counts (read & write) ────────────────────────────────────────────────
+
+async function getCountFor(env: Env, code: string): Promise<number> {
+  const stored = await env.ENCUESTA_MUNDIAL.get(`count:${code}`);
+  if (stored !== null) return Number.parseInt(stored, 10);
+  return INITIAL_COUNTS[code] ?? 0;
+}
+
+async function setCountFor(env: Env, code: string, value: number): Promise<void> {
+  await env.ENCUESTA_MUNDIAL.put(`count:${code}`, String(Math.max(0, value)));
+}
+
+async function readAllCounts(env: Env): Promise<Record<string, number>> {
+  const counts: Record<string, number> = {};
+  await Promise.all(
+    Array.from(TOURNAMENT_TEAMS).map(async (code) => {
+      counts[code] = await getCountFor(env, code);
+    }),
+  );
+  return counts;
+}
+
+// ─── Vote logic ───────────────────────────────────────────────────────────
+
+async function registerVote(env: Env, team: string, voterId: string): Promise<{ changed: boolean }> {
+  const previousTeam = await env.ENCUESTA_MUNDIAL.get(`voter:${voterId}`);
+  if (previousTeam === team) return { changed: false };
+
+  if (previousTeam && TOURNAMENT_TEAMS.has(previousTeam)) {
+    const prev = await getCountFor(env, previousTeam);
+    await setCountFor(env, previousTeam, prev - 1);
+  }
+
+  const curr = await getCountFor(env, team);
+  await setCountFor(env, team, curr + 1);
+
+  const ttlSeconds = Number.parseInt(env.VOTER_TTL_DAYS, 10) * 24 * 60 * 60;
+  await env.ENCUESTA_MUNDIAL.put(`voter:${voterId}`, team, { expirationTtl: ttlSeconds });
+
+  return { changed: true };
+}
+
+// ─── HTTP handlers ────────────────────────────────────────────────────────
+
+async function handleGet(env: Env, cors: Record<string, string>): Promise<Response> {
+  const counts = await readAllCounts(env);
+  const total = Object.values(counts).reduce((s, n) => s + n, 0);
+  return json({ counts, total }, { headers: { ...cors, 'Cache-Control': 'public, max-age=10' } });
+}
+
+async function handlePost(req: Request, env: Env, cors: Record<string, string>): Promise<Response> {
+  let body: { team?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: 'JSON inválido' }, { status: 400, headers: cors });
+  }
+
+  const team = typeof body.team === 'string' ? body.team.toUpperCase() : '';
+  if (!team || !TOURNAMENT_TEAMS.has(team)) {
+    return json({ error: `Equipo no válido: ${team || '(vacío)'}` }, { status: 400, headers: cors });
+  }
+
+  const voterId = await hashVoterId(req);
+  const { changed } = await registerVote(env, team, voterId);
+
+  // Tras un voto, devolvemos counts frescos para que el frontend pinte el
+  // nuevo podium sin un segundo round-trip.
+  const counts = await readAllCounts(env);
+  const total = Object.values(counts).reduce((s, n) => s + n, 0);
+  return json(
+    { changed, vote: team, counts, total },
+    { headers: { ...cors, 'Cache-Control': 'no-store' } },
+  );
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const cors = corsHeaders(req.headers.get('origin'), env);
+
+    if (req.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: cors });
+    }
+    if (req.method === 'GET') {
+      return handleGet(env, cors);
+    }
+    if (req.method === 'POST') {
+      return handlePost(req, env, cors);
+    }
+    return json({ error: 'Método no permitido' }, { status: 405, headers: { ...cors, Allow: 'GET, POST, OPTIONS' } });
+  },
+} satisfies ExportedHandler<Env>;

--- a/workers/encuesta-mundial/tsconfig.json
+++ b/workers/encuesta-mundial/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/encuesta-mundial/wrangler.toml
+++ b/workers/encuesta-mundial/wrangler.toml
@@ -1,0 +1,27 @@
+name = "minigolclub-encuesta-mundial"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+
+# Sin cron — este worker responde HTTP requests, no tareas programadas.
+
+[vars]
+# Origins permitidos para CORS. Editar antes de deploy.
+ALLOWED_ORIGINS = "https://minigolclub.com,https://www.minigolclub.com,http://localhost:4321,http://localhost:4322"
+
+# Días que el ID de votante queda registrado en KV. Tras este TTL puede votar
+# de nuevo (o cambiar voto). 90 días cubre el periodo pre-Mundial + torneo.
+VOTER_TTL_DAYS = "90"
+
+# KV para contadores por equipo (key `count:<ISO3>`) y registro de votantes
+# (key `voter:<sha256-of-ip-ua>`). Crear con:
+#   wrangler kv namespace create ENCUESTA_MUNDIAL
+# Luego pegar el `id` devuelto debajo (sin cambiar el `binding`).
+[[kv_namespaces]]
+binding = "ENCUESTA_MUNDIAL"
+id = "REEMPLAZAR_TRAS_CREAR_KV"
+
+# Para deploy bajo un dominio propio (recomendado, evita CORS):
+#   uncomment + editar el bloque [[routes]] antes de `wrangler deploy`.
+# [[routes]]
+# pattern = "minigolclub.com/api/encuesta-campeon*"
+# zone_name = "minigolclub.com"

--- a/workers/encuesta-mundial/wrangler.toml
+++ b/workers/encuesta-mundial/wrangler.toml
@@ -18,7 +18,7 @@ VOTER_TTL_DAYS = "90"
 # Luego pegar el `id` devuelto debajo (sin cambiar el `binding`).
 [[kv_namespaces]]
 binding = "ENCUESTA_MUNDIAL"
-id = "REEMPLAZAR_TRAS_CREAR_KV"
+id = "9da405c876a74055b4e78839928b050c"
 
 # Para deploy bajo un dominio propio (recomendado, evita CORS):
 #   uncomment + editar el bloque [[routes]] antes de `wrangler deploy`.


### PR DESCRIPTION
## Resumen

Antes la encuesta del Mundial era 100% local: localStorage por dispositivo + counts mock hardcoded. El podium "top 3" se calculaba con los mismos seed para todos los visitantes, divertido pero sin valor agregado real.

Esta PR añade el backend mínimo para **agregar votos reales entre todos los usuarios**.

## Arquitectura

\`\`\`
[frontend Astro] ──fetch──> [Cloudflare Worker] ──read/write──> [KV ENCUESTA_MUNDIAL]
   EncuestaCampeon.tsx          src/index.ts                      count:<ISO3>, voter:<hash>
\`\`\`

### Worker (\`workers/encuesta-mundial/\`)

- \`GET /\` → \`{ counts: { ISO3: número }, total }\`. Fallback a \`INITIAL_COUNTS\` para KV vacía → la encuesta arranca con escenario realista.
- \`POST /\` body \`{ team: "ISO3" }\` → registra voto. Valida contra las 48 selecciones reales (rechaza ISO3 fuera del torneo).
- \`OPTIONS /\` → CORS preflight.
- **Un voto por dispositivo** (hash SHA-256 de IP+UA, TTL configurable 90 días default). Si vota de nuevo: decrementa el equipo anterior, incrementa el nuevo.
- **CORS por allowlist** configurable en \`wrangler.toml\` (\`ALLOWED_ORIGINS\`).

### Frontend

\`PUBLIC_ENCUESTA_API_URL\` opcional:
- **Set + Worker responde:** counts agregados de KV. Voto se postea al servidor. Todos ven el mismo podium en tiempo real.
- **No set / Worker down:** modo offline. Seed counts + localStorage. La encuesta funciona visualmente igual, solo no se agrega entre dispositivos.

Sin breaking change. El componente sigue trabajando si nunca se despliega el Worker.

## Setup operativo (1 vez)

Documentado en [\`workers/encuesta-mundial/README.md\`](workers/encuesta-mundial/README.md):

\`\`\`bash
cd workers/encuesta-mundial
pnpm install
pnpm exec wrangler login
pnpm exec wrangler kv namespace create ENCUESTA_MUNDIAL
# pegar el id devuelto en wrangler.toml
pnpm deploy
# añadir PUBLIC_ENCUESTA_API_URL=<url-del-worker> al .env del frontend
\`\`\`

## Decisiones

- **KV en vez de Durable Objects:** simplicidad. KV no es atómico read-then-write → dos votos simultáneos al mismo equipo pueden perder uno. Para ~cientos/día aceptable. Migrar si se vuelve viral.
- **Sin auth, sin captcha:** encuesta lúdica infantil. Bypass posible con VPN/incognito — coste-beneficio claro.
- **Tres constantes a mantener en sync** (documentado en README): \`TOURNAMENT_TEAMS\` ↔ \`SELECCIONES_DEL_TORNEO\`, \`INITIAL_COUNTS\` Worker ↔ \`INITIAL_COUNTS\` frontend, allowed origins.

## Test plan

- [ ] \`cd workers/encuesta-mundial && pnpm install && pnpm exec tsc --noEmit\` → sin errores.
- [ ] Setup del Worker (crear KV, deploy) según README.
- [ ] \`curl https://<worker-url>/\` → JSON con seed counts.
- [ ] \`curl -X POST -H "Content-Type: application/json" -d '{"team":"ARG"}' https://<worker-url>/\` → counts con ARG+1.
- [ ] Frontend con \`PUBLIC_ENCUESTA_API_URL=...\`: visitar \`/mundial-2026/\`, votar, abrir otra tab/dispositivo → debería ver tu voto reflejado en el podium.
- [ ] Frontend sin \`PUBLIC_ENCUESTA_API_URL\` o con URL inválida: encuesta sigue funcionando offline (seed counts + voto local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)